### PR TITLE
🚀 Release: ER Save Manager 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,46 @@
+# 📜 ER Save Manager - Release History
+
+> A comprehensive changelog for the Elden Ring Save Manager application.
+> All notable changes to this project are documented here.
+
+## 📦 Release 0.1.0
+**Released:** January 17, 2026
+
+
+### ✨ New Features
+
+- Added release workflow ([23d78a0](https://github.com/Hapfel1/er-save-manager/commit/23d78a0f88c0f2ea69ed5f7cce2f530a6c070ab4))
+
+- Added gui, implemented functions partially ([f464292](https://github.com/Hapfel1/er-save-manager/commit/f464292b162e50b742a3bebaa77b5909e3d9e8e4))
+
+- Feat: add new gui features (templates for further
+implementation) ([77f66e6](https://github.com/Hapfel1/er-save-manager/commit/77f66e6a1d4f1b447076077fcc1cfd06a608daab))
+
+- Add automatic release workflow and build scripts ([45d2d35](https://github.com/Hapfel1/er-save-manager/commit/45d2d352e042ecb5c6cb918eff391c4e69141107))
+
+
+
+### 🔧 Bug Fixes
+
+- Edited readme correctly ([2ac2bbf](https://github.com/Hapfel1/er-save-manager/commit/2ac2bbfd4e9467b2e61b72b8b640a8b095ab6a3a))
+
+- README ([af552da](https://github.com/Hapfel1/er-save-manager/commit/af552da648184d5824f0e9bd3a8ae36fdf5bfdab))
+
+- Lint and format ([a248bda](https://github.com/Hapfel1/er-save-manager/commit/a248bdac119d579495ff486ad6edcbcd5d873a11))
+
+- Fix import ([1f2d05c](https://github.com/Hapfel1/er-save-manager/commit/1f2d05cb689939aa6a1a2f11dbcf5bd848401040))
+
+- Set executable permissions for shell scripts ([5d47267](https://github.com/Hapfel1/er-save-manager/commit/5d47267d0179b74d6b937e093b47d7fcfaf76256))
+
+- Fix ci.yml ([e94a478](https://github.com/Hapfel1/er-save-manager/commit/e94a478dbaf41dce38d8c39ffa313b7d3539d11b))
+
+
+
+### 🧹 Maintenance
+
+- Repo URLs in cliff.toml for upstream ([90bcc63](https://github.com/Hapfel1/er-save-manager/commit/90bcc63dff7db7eeb94e54394131d4fbaf1a01e4))
+
+
+
+---
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "er-save-manager"
-version = "0.0.1"
+version = "0.1.0"
 description = "Elden Ring Save File Editor, Backup Manager, and Corruption Fixer"
 readme = "README.md"
 license = { text = "MIT" }

--- a/uv.lock
+++ b/uv.lock
@@ -86,7 +86,7 @@ wheels = [
 
 [[package]]
 name = "er-save-manager"
-version = "0.0.1"
+version = "0.1.0"
 source = { editable = "." }
 
 [package.dev-dependencies]
@@ -230,7 +230,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/89/a9/a9a2103e159fd65bffbc21ecc5c8c36e44eb34fe53b4ef85fb6d08c2a635/patchelf-0.17.2.4-py3-none-manylinux2014_armv7l.manylinux_2_17_armv7l.musllinux_1_1_armv7l.whl", hash = "sha256:ae44cb3c857d50f54b99e5697aa978726ada33a8a6129d4b8b7ffd28b996652d", size = 431226, upload-time = "2025-07-23T21:16:26.765Z" },
     { url = "https://files.pythonhosted.org/packages/87/93/897d612f6df7cfd987bdf668425127efeff8d8e4ad8bfbab1c69d2a0d861/patchelf-0.17.2.4-py3-none-manylinux2014_ppc64le.manylinux_2_17_ppc64le.musllinux_1_1_ppc64le.whl", hash = "sha256:680a266a70f60a7a4f4c448482c5bdba80cc8e6bb155a49dcc24238ba49927b0", size = 540276, upload-time = "2025-07-23T21:16:27.983Z" },
     { url = "https://files.pythonhosted.org/packages/5d/b8/2b92d11533482bac9ee989081d6880845287751b5f528adbd6bb27667fbd/patchelf-0.17.2.4-py3-none-manylinux2014_s390x.manylinux_2_17_s390x.musllinux_1_1_s390x.whl", hash = "sha256:d842b51f0401460f3b1f3a3a67d2c266a8f515a5adfbfa6e7b656cb3ac2ed8bc", size = 596632, upload-time = "2025-07-23T21:16:29.253Z" },
-    { url = "https://files.pythonhosted.org/packages/14/e2/975d4bdb418f942b53e6187b95bd9e0d5e0488b7bc214685a1e43e2c2751/patchelf-0.17.2.4-py3-none-manylinux_2_31_riscv64.musllinux_1_1_riscv64.whl", hash = "sha256:7076d9e127230982e20a81a6e2358d3343004667ba510d9f822d4fdee29b0d71", size = 508281, upload-time = "2025-07-23T21:16:30.865Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 🚧 UNRELEASED

**This release is still under development.**
Changes in this PR will be included in the final release once merged.

---

## 📦 Release 0.1.0
**Released:** January 17, 2026


### ✨ New Features

- Added release workflow ([23d78a0](https://github.com/Hapfel1/er-save-manager/commit/23d78a0f88c0f2ea69ed5f7cce2f530a6c070ab4))

- Added gui, implemented functions partially ([f464292](https://github.com/Hapfel1/er-save-manager/commit/f464292b162e50b742a3bebaa77b5909e3d9e8e4))

- Feat: add new gui features (templates for further
implementation) ([77f66e6](https://github.com/Hapfel1/er-save-manager/commit/77f66e6a1d4f1b447076077fcc1cfd06a608daab))

- Add automatic release workflow and build scripts ([45d2d35](https://github.com/Hapfel1/er-save-manager/commit/45d2d352e042ecb5c6cb918eff391c4e69141107))



### 🔧 Bug Fixes

- Edited readme correctly ([2ac2bbf](https://github.com/Hapfel1/er-save-manager/commit/2ac2bbfd4e9467b2e61b72b8b640a8b095ab6a3a))

- README ([af552da](https://github.com/Hapfel1/er-save-manager/commit/af552da648184d5824f0e9bd3a8ae36fdf5bfdab))

- Lint and format ([a248bda](https://github.com/Hapfel1/er-save-manager/commit/a248bdac119d579495ff486ad6edcbcd5d873a11))

- Fix import ([1f2d05c](https://github.com/Hapfel1/er-save-manager/commit/1f2d05cb689939aa6a1a2f11dbcf5bd848401040))

- Set executable permissions for shell scripts ([5d47267](https://github.com/Hapfel1/er-save-manager/commit/5d47267d0179b74d6b937e093b47d7fcfaf76256))

- Fix ci.yml ([e94a478](https://github.com/Hapfel1/er-save-manager/commit/e94a478dbaf41dce38d8c39ffa313b7d3539d11b))



### 🧹 Maintenance

- Repo URLs in cliff.toml for upstream ([90bcc63](https://github.com/Hapfel1/er-save-manager/commit/90bcc63dff7db7eeb94e54394131d4fbaf1a01e4))