### PR TITLE
🚀 Release: ER Save Manager v0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 > A comprehensive changelog for the Elden Ring Save Manager application.
 > All notable changes to this project are documented here.
 
+## 📦 Release 0.6.2
+**Released:** January 27, 2026
+
+
+### 🔧 Bug Fixes
+
+- Fixed workflow version numbering ([9d6c841](https://github.com/Hapfel1/er-save-manager/commit/9d6c84159c6ac555b9541b1752ee66b13bb85671))
+
+
+
+---
 ## 📦 Release 0.6.1
 **Released:** January 27, 2026
 
@@ -291,6 +302,7 @@ implementation) ([77f66e6](https://github.com/Hapfel1/er-save-manager/commit/77f
 
 
 ---
+[0.6.2]: https://github.com/Hapfel1/er-save-manager/compare/v0.6.1..v0.6.2
 [0.6.1]: https://github.com/Hapfel1/er-save-manager/compare/v0.6.0..v0.6.1
 [0.6.0]: https://github.com/Hapfel1/er-save-manager/compare/v0.5.1..v0.6.0
 [0.5.1]: https://github.com/Hapfel1/er-save-manager/compare/v0.5.0..v0.5.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "er-save-manager"
-version = "0.6.1"
+version = "0.6.2"
 description = "Elden Ring Save File Editor, Backup Manager, and Corruption Fixer"
 readme = "README.md"
 license = "MIT"

--- a/resources/app.manifest
+++ b/resources/app.manifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
   <assemblyIdentity
-    version="0.5.0.0"
+    version="0.6.2.0"
     processorArchitecture="x86"
     name="ER.Save.Manager"
     type="win32"

--- a/resources/version.txt
+++ b/resources/version.txt
@@ -1,6 +1,6 @@
-version=0.5.0.0
-file_version=0.5.0.0
-product_version=0.5.0.0
+version=0.6.2.0
+file_version=0.6.2.0
+product_version=0.6.2.0
 company=ER Save Manager Contributors
 description=Elden Ring Save File Manager
 product=ER Save Manager

--- a/uv.lock
+++ b/uv.lock
@@ -325,7 +325,7 @@ wheels = [
 
 [[package]]
 name = "er-save-manager"
-version = "0.6.1"
+version = "0.6.2"
 source = { editable = "." }
 dependencies = [
     { name = "customtkinter" },


### PR DESCRIPTION
## 🚧 UNRELEASED

**This release is still under development.**
Changes in this PR will be included in the final release once merged.

---

## 📦 Release 0.6.2
**Released:** January 27, 2026


### 🔧 Bug Fixes

- Fixed workflow version numbering ([9d6c841](https://github.com/Hapfel1/er-save-manager/commit/9d6c84159c6ac555b9541b1752ee66b13bb85671))



---