### PR TITLE
🚀 Release: ER Save Manager v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 > A comprehensive changelog for the Elden Ring Save Manager application.
 > All notable changes to this project are documented here.
 
+## 📦 Release 0.7.1
+**Released:** January 28, 2026
+
+
+### 🔧 Bug Fixes
+
+- Fixed error message pop-up when no actual error happened ([a5e6337](https://github.com/Hapfel1/er-save-manager/commit/a5e6337f8d2389588f0e6d3279ed771e4fa61b71))
+
+
+
+---
 ## 📦 Release 0.7.0
 **Released:** January 28, 2026
 
@@ -327,6 +338,7 @@ implementation) ([77f66e6](https://github.com/Hapfel1/er-save-manager/commit/77f
 
 
 ---
+[0.7.1]: https://github.com/Hapfel1/er-save-manager/compare/v0.7.0..v0.7.1
 [0.7.0]: https://github.com/Hapfel1/er-save-manager/compare/v0.6.2..v0.7.0
 [0.6.2]: https://github.com/Hapfel1/er-save-manager/compare/v0.6.1..v0.6.2
 [0.6.1]: https://github.com/Hapfel1/er-save-manager/compare/v0.6.0..v0.6.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "er-save-manager"
-version = "0.7.0"
+version = "0.7.1"
 description = "Elden Ring Save File Editor, Backup Manager, and Corruption Fixer"
 readme = "README.md"
 license = "MIT"

--- a/resources/app.manifest
+++ b/resources/app.manifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
   <assemblyIdentity
-    version="0.7.0.0"
+    version="0.7.1.0"
     processorArchitecture="x86"
     name="ER.Save.Manager"
     type="win32"

--- a/resources/version.txt
+++ b/resources/version.txt
@@ -1,6 +1,6 @@
-version=0.7.0.0
-file_version=0.7.0.0
-product_version=0.7.0.0
+version=0.7.1.0
+file_version=0.7.1.0
+product_version=0.7.1.0
 company=ER Save Manager Contributors
 description=Elden Ring Save File Manager
 product=ER Save Manager

--- a/uv.lock
+++ b/uv.lock
@@ -325,7 +325,7 @@ wheels = [
 
 [[package]]
 name = "er-save-manager"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "customtkinter" },


### PR DESCRIPTION
## 🚧 UNRELEASED

**This release is still under development.**
Changes in this PR will be included in the final release once merged.

---

## 📦 Release 0.7.1
**Released:** January 28, 2026


### 🔧 Bug Fixes

- Fixed error message pop-up when no actual error happened ([a5e6337](https://github.com/Hapfel1/er-save-manager/commit/a5e6337f8d2389588f0e6d3279ed771e4fa61b71))



---