### PR TITLE
🚀 Release: ER Save Manager v0.7.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@
 > A comprehensive changelog for the Elden Ring Save Manager application.
 > All notable changes to this project are documented here.
 
+## 📦 Release 0.7.4
+**Released:** January 31, 2026
+
+
+### 🔧 Bug Fixes
+
+- Fixed JSON import error msg ([36c73c1](https://github.com/Hapfel1/er-save-manager/commit/36c73c11f1d47fe9937b57b6757e796d83d81d66))
+
+
+
+### 🎨 User Interface
+
+- Change default theme to dark ([6516a42](https://github.com/Hapfel1/er-save-manager/commit/6516a42182316f9065677645df424c9087ca2c4f))
+
+
+
+---
 ## 📦 Release 0.7.3
 **Released:** January 30, 2026
 
@@ -376,6 +393,7 @@ implementation) ([77f66e6](https://github.com/Hapfel1/er-save-manager/commit/77f
 
 
 ---
+[0.7.4]: https://github.com/Hapfel1/er-save-manager/compare/v0.7.3..v0.7.4
 [0.7.3]: https://github.com/Hapfel1/er-save-manager/compare/v0.7.2..v0.7.3
 [0.7.2]: https://github.com/Hapfel1/er-save-manager/compare/v0.7.1..v0.7.2
 [0.7.1]: https://github.com/Hapfel1/er-save-manager/compare/v0.7.0..v0.7.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "er-save-manager"
-version = "0.7.3"
+version = "0.7.4"
 description = "Elden Ring Save File Editor, Backup Manager, and Corruption Fixer"
 readme = "README.md"
 license = "MIT"

--- a/resources/app.manifest
+++ b/resources/app.manifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
   <assemblyIdentity
-    version="0.7.3.0"
+    version="0.7.4.0"
     processorArchitecture="x86"
     name="ER.Save.Manager"
     type="win32"

--- a/resources/version.txt
+++ b/resources/version.txt
@@ -1,6 +1,6 @@
-version=0.7.3.0
-file_version=0.7.3.0
-product_version=0.7.3.0
+version=0.7.4.0
+file_version=0.7.4.0
+product_version=0.7.4.0
 company=ER Save Manager Contributors
 description=Elden Ring Save File Manager
 product=ER Save Manager

--- a/uv.lock
+++ b/uv.lock
@@ -325,7 +325,7 @@ wheels = [
 
 [[package]]
 name = "er-save-manager"
-version = "0.7.3"
+version = "0.7.4"
 source = { editable = "." }
 dependencies = [
     { name = "customtkinter" },


### PR DESCRIPTION
## 🚧 UNRELEASED

**This release is still under development.**
Changes in this PR will be included in the final release once merged.

---

## 📦 Release 0.7.4
**Released:** January 31, 2026


### 🔧 Bug Fixes

- Fixed JSON import error msg ([36c73c1](https://github.com/Hapfel1/er-save-manager/commit/36c73c11f1d47fe9937b57b6757e796d83d81d66))



### 🎨 User Interface

- Change default theme to dark ([6516a42](https://github.com/Hapfel1/er-save-manager/commit/6516a42182316f9065677645df424c9087ca2c4f))



---