### PR TITLE
🚀 Release: ER Save Manager v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,25 @@
 > A comprehensive changelog for the Elden Ring Save Manager application.
 > All notable changes to this project are documented here.
 
+## 📦 Release 0.8.0
+**Released:** February 02, 2026
+
+
+### ✨ New Features
+
+- Added version checker to notify users of new update ([757c4b1](https://github.com/Hapfel1/er-save-manager/commit/757c4b1a2a1c458e3ad3bc96c17e5147d2e34d72))
+
+- Add Troubleshooter for checking game und save file related issues ([f0f850b](https://github.com/Hapfel1/er-save-manager/commit/f0f850b6050e0ef33f5092fdbb7374bfa2d45064))
+
+
+
+### 🔧 Bug Fixes
+
+- Fixed SteamDeck not showing Preset Browser correctly bc of SSL errors ([ea6794b](https://github.com/Hapfel1/er-save-manager/commit/ea6794b0cffdf812d1942a4158d79cbf3718e82c))
+
+
+
+---
 ## 📦 Release 0.7.4
 **Released:** January 31, 2026
 
@@ -393,6 +412,7 @@ implementation) ([77f66e6](https://github.com/Hapfel1/er-save-manager/commit/77f
 
 
 ---
+[0.8.0]: https://github.com/Hapfel1/er-save-manager/compare/v0.7.4..v0.8.0
 [0.7.4]: https://github.com/Hapfel1/er-save-manager/compare/v0.7.3..v0.7.4
 [0.7.3]: https://github.com/Hapfel1/er-save-manager/compare/v0.7.2..v0.7.3
 [0.7.2]: https://github.com/Hapfel1/er-save-manager/compare/v0.7.1..v0.7.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "er-save-manager"
-version = "0.7.4"
+version = "0.8.0"
 description = "Elden Ring Save File Editor, Backup Manager, and Corruption Fixer"
 readme = "README.md"
 license = "MIT"

--- a/resources/app.manifest
+++ b/resources/app.manifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
   <assemblyIdentity
-    version="0.7.4.0"
+    version="0.8.0.0"
     processorArchitecture="x86"
     name="ER.Save.Manager"
     type="win32"

--- a/resources/version.txt
+++ b/resources/version.txt
@@ -1,6 +1,6 @@
-version=0.7.4.0
-file_version=0.7.4.0
-product_version=0.7.4.0
+version=0.8.0.0
+file_version=0.8.0.0
+product_version=0.8.0.0
 company=ER Save Manager Contributors
 description=Elden Ring Save File Manager
 product=ER Save Manager

--- a/src/er_save_manager/__init__.py
+++ b/src/er_save_manager/__init__.py
@@ -26,4 +26,4 @@ __all__ = [
     "VersionChecker",
 ]
 
-__version__ = "0.7.4"
+__version__ = "0.8.0"

--- a/uv.lock
+++ b/uv.lock
@@ -325,7 +325,7 @@ wheels = [
 
 [[package]]
 name = "er-save-manager"
-version = "0.7.4"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "certifi" },
@@ -744,7 +744,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/89/a9/a9a2103e159fd65bffbc21ecc5c8c36e44eb34fe53b4ef85fb6d08c2a635/patchelf-0.17.2.4-py3-none-manylinux2014_armv7l.manylinux_2_17_armv7l.musllinux_1_1_armv7l.whl", hash = "sha256:ae44cb3c857d50f54b99e5697aa978726ada33a8a6129d4b8b7ffd28b996652d", size = 431226, upload-time = "2025-07-23T21:16:26.765Z" },
     { url = "https://files.pythonhosted.org/packages/87/93/897d612f6df7cfd987bdf668425127efeff8d8e4ad8bfbab1c69d2a0d861/patchelf-0.17.2.4-py3-none-manylinux2014_ppc64le.manylinux_2_17_ppc64le.musllinux_1_1_ppc64le.whl", hash = "sha256:680a266a70f60a7a4f4c448482c5bdba80cc8e6bb155a49dcc24238ba49927b0", size = 540276, upload-time = "2025-07-23T21:16:27.983Z" },
     { url = "https://files.pythonhosted.org/packages/5d/b8/2b92d11533482bac9ee989081d6880845287751b5f528adbd6bb27667fbd/patchelf-0.17.2.4-py3-none-manylinux2014_s390x.manylinux_2_17_s390x.musllinux_1_1_s390x.whl", hash = "sha256:d842b51f0401460f3b1f3a3a67d2c266a8f515a5adfbfa6e7b656cb3ac2ed8bc", size = 596632, upload-time = "2025-07-23T21:16:29.253Z" },
-    { url = "https://files.pythonhosted.org/packages/14/e2/975d4bdb418f942b53e6187b95bd9e0d5e0488b7bc214685a1e43e2c2751/patchelf-0.17.2.4-py3-none-manylinux_2_31_riscv64.musllinux_1_1_riscv64.whl", hash = "sha256:7076d9e127230982e20a81a6e2358d3343004667ba510d9f822d4fdee29b0d71", size = 508281, upload-time = "2025-07-23T21:16:30.865Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 🚧 UNRELEASED

**This release is still under development.**
Changes in this PR will be included in the final release once merged.

---

## 📦 Release 0.8.0
**Released:** February 02, 2026


### ✨ New Features

- Added version checker to notify users of new update ([757c4b1](https://github.com/Hapfel1/er-save-manager/commit/757c4b1a2a1c458e3ad3bc96c17e5147d2e34d72))

- Add Troubleshooter for checking game und save file related issues ([f0f850b](https://github.com/Hapfel1/er-save-manager/commit/f0f850b6050e0ef33f5092fdbb7374bfa2d45064))



### 🔧 Bug Fixes

- Fixed SteamDeck not showing Preset Browser correctly bc of SSL errors ([ea6794b](https://github.com/Hapfel1/er-save-manager/commit/ea6794b0cffdf812d1942a4158d79cbf3718e82c))



---