### PR TITLE
🚀 Release: ER Save Manager v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 > A comprehensive changelog for the Elden Ring Save Manager application.
 > All notable changes to this project are documented here.
 
+## 📦 Release 0.9.1
+**Released:** February 03, 2026
+
+
+### 🔧 Bug Fixes
+
+- Fixed appimage build to include the custom lavender theme correctly ([381481d](https://github.com/Hapfel1/er-save-manager/commit/381481d5a8fec155b1cf598ce7105008837c96b5))
+
+
+
+---
 ## 📦 Release 0.9.0
 **Released:** February 03, 2026
 
@@ -437,6 +448,7 @@ implementation) ([77f66e6](https://github.com/Hapfel1/er-save-manager/commit/77f
 
 
 ---
+[0.9.1]: https://github.com/Hapfel1/er-save-manager/compare/v0.9.0..v0.9.1
 [0.9.0]: https://github.com/Hapfel1/er-save-manager/compare/v0.8.0..v0.9.0
 [0.8.0]: https://github.com/Hapfel1/er-save-manager/compare/v0.7.4..v0.8.0
 [0.7.4]: https://github.com/Hapfel1/er-save-manager/compare/v0.7.3..v0.7.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "er-save-manager"
-version = "0.9.0"
+version = "0.9.1"
 description = "Elden Ring Save File Editor, Backup Manager, and Corruption Fixer"
 readme = "README.md"
 license = "MIT"

--- a/resources/app.manifest
+++ b/resources/app.manifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
   <assemblyIdentity
-    version="0.9.0.0"
+    version="0.9.1.0"
     processorArchitecture="x86"
     name="ER.Save.Manager"
     type="win32"

--- a/resources/version.txt
+++ b/resources/version.txt
@@ -1,6 +1,6 @@
-version=0.9.0.0
-file_version=0.9.0.0
-product_version=0.9.0.0
+version=0.9.1.0
+file_version=0.9.1.0
+product_version=0.9.1.0
 company=ER Save Manager Contributors
 description=Elden Ring Save File Manager
 product=ER Save Manager

--- a/src/er_save_manager/__init__.py
+++ b/src/er_save_manager/__init__.py
@@ -26,4 +26,4 @@ __all__ = [
     "VersionChecker",
 ]
 
-__version__ = "0.9.0"
+__version__ = "0.9.1"

--- a/uv.lock
+++ b/uv.lock
@@ -325,7 +325,7 @@ wheels = [
 
 [[package]]
 name = "er-save-manager"
-version = "0.9.0"
+version = "0.9.1"
 source = { editable = "." }
 dependencies = [
     { name = "certifi" },


### PR DESCRIPTION
## 🚧 UNRELEASED

**This release is still under development.**
Changes in this PR will be included in the final release once merged.

---

## 📦 Release 0.9.1
**Released:** February 03, 2026


### 🔧 Bug Fixes

- Fixed appimage build to include the custom lavender theme correctly ([381481d](https://github.com/Hapfel1/er-save-manager/commit/381481d5a8fec155b1cf598ce7105008837c96b5))



---