### PR TITLE
Fix for save corruption issues introduced in 0.11.0

### DIFF
--- a/src/er_save_manager/editors/world_state.py
+++ b/src/er_save_manager/editors/world_state.py
@@ -131,7 +131,7 @@ class WorldStateEditor:
 
         # PlayerCoordinates.map_id at coordinates_offset + 12
         if hasattr(slot, "coordinates_offset") and slot.coordinates_offset:
-            coord_base = slot.data_start + slot.coordinates_offset
+            coord_base = slot.coordinates_offset
             pc_map_id_offset = coord_base + 12
             raw[pc_map_id_offset : pc_map_id_offset + 4] = map_id.data
             try:
@@ -158,7 +158,7 @@ class WorldStateEditor:
         if not hasattr(slot, "coordinates_offset") or slot.coordinates_offset == 0:
             raise RuntimeError("coordinates_offset not available")
 
-        offset = slot.data_start + slot.coordinates_offset
+        offset = slot.coordinates_offset
         raw = self._save._raw_data
         raw[offset : offset + 4] = struct.pack("<f", coords.x)
         raw[offset + 4 : offset + 8] = struct.pack("<f", coords.y)

--- a/src/er_save_manager/fixes/dlc.py
+++ b/src/er_save_manager/fixes/dlc.py
@@ -53,9 +53,7 @@ class DLCFlagFix(BaseFix):
             dlc_bytes = BytesIO()
             slot.dlc.write(dlc_bytes)
             dlc_data = dlc_bytes.getvalue()
-            save._raw_data[
-                slot.dlc_offset : slot.dlc_offset + len(dlc_data)
-            ] = dlc_data
+            save._raw_data[slot.dlc_offset : slot.dlc_offset + len(dlc_data)] = dlc_data
 
             return FixResult(
                 applied=True,
@@ -105,9 +103,7 @@ class InvalidDLCFix(BaseFix):
             dlc_bytes = BytesIO()
             slot.dlc.write(dlc_bytes)
             dlc_data = dlc_bytes.getvalue()
-            save._raw_data[
-                slot.dlc_offset : slot.dlc_offset + len(dlc_data)
-            ] = dlc_data
+            save._raw_data[slot.dlc_offset : slot.dlc_offset + len(dlc_data)] = dlc_data
 
             return FixResult(
                 applied=True,

--- a/src/er_save_manager/fixes/dlc.py
+++ b/src/er_save_manager/fixes/dlc.py
@@ -53,10 +53,8 @@ class DLCFlagFix(BaseFix):
             dlc_bytes = BytesIO()
             slot.dlc.write(dlc_bytes)
             dlc_data = dlc_bytes.getvalue()
-            # Calculate absolute offset
-            absolute_dlc_offset = slot.data_start + slot.dlc_offset
             save._raw_data[
-                absolute_dlc_offset : absolute_dlc_offset + len(dlc_data)
+                slot.dlc_offset : slot.dlc_offset + len(dlc_data)
             ] = dlc_data
 
             return FixResult(
@@ -107,10 +105,8 @@ class InvalidDLCFix(BaseFix):
             dlc_bytes = BytesIO()
             slot.dlc.write(dlc_bytes)
             dlc_data = dlc_bytes.getvalue()
-            # Calculate absolute offset
-            absolute_dlc_offset = slot.data_start + slot.dlc_offset
             save._raw_data[
-                absolute_dlc_offset : absolute_dlc_offset + len(dlc_data)
+                slot.dlc_offset : slot.dlc_offset + len(dlc_data)
             ] = dlc_data
 
             return FixResult(

--- a/src/er_save_manager/fixes/event_flags.py
+++ b/src/er_save_manager/fixes/event_flags.py
@@ -69,10 +69,8 @@ class EventFlagsFix(BaseFix):
 
         # Write to raw data
         if hasattr(slot, "event_flags_offset") and slot.event_flags_offset > 0:
-            # Calculate absolute offset
-            absolute_event_flags_offset = slot.data_start + slot.event_flags_offset
             save._raw_data[
-                absolute_event_flags_offset : absolute_event_flags_offset
+                slot.event_flags_offset : slot.event_flags_offset
                 + len(event_flags_mutable)
             ] = event_flags_mutable
 
@@ -118,10 +116,8 @@ class RanniSoftlockFix(BaseFix):
             slot.event_flags = bytes(event_flags_mutable)
 
             if hasattr(slot, "event_flags_offset") and slot.event_flags_offset > 0:
-                # Calculate absolute offset
-                absolute_event_flags_offset = slot.data_start + slot.event_flags_offset
                 save._raw_data[
-                    absolute_event_flags_offset : absolute_event_flags_offset
+                    slot.event_flags_offset : slot.event_flags_offset
                     + len(event_flags_mutable)
                 ] = event_flags_mutable
 

--- a/src/er_save_manager/fixes/steamid.py
+++ b/src/er_save_manager/fixes/steamid.py
@@ -56,13 +56,8 @@ class SteamIdFix(BaseFix):
 
         # Write to raw data
         if hasattr(slot, "steamid_offset") and slot.steamid_offset > 0:
-            # Calculate absolute offset in save file
-            # steamid_offset is relative to the stream position when parsing started (data_start)
-            # data_start is the absolute position in the file (stored in slot.data_start)
-            absolute_steamid_offset = slot.data_start + slot.steamid_offset
-
             steamid_bytes = struct.pack("<Q", correct_steam_id)
-            save._raw_data[absolute_steamid_offset : absolute_steamid_offset + 8] = (
+            save._raw_data[slot.steamid_offset : slot.steamid_offset + 8] = (
                 steamid_bytes
             )
 

--- a/src/er_save_manager/fixes/time_sync.py
+++ b/src/er_save_manager/fixes/time_sync.py
@@ -70,9 +70,9 @@ class TimeFix(BaseFix):
             time_bytes = BytesIO()
             time.write(time_bytes)
             time_data = time_bytes.getvalue()
-            save._raw_data[
-                slot.time_offset : slot.time_offset + len(time_data)
-            ] = time_data
+            save._raw_data[slot.time_offset : slot.time_offset + len(time_data)] = (
+                time_data
+            )
 
             new_time = f"{hours:02d}:{minutes:02d}:{seconds:02d}"
             return FixResult(

--- a/src/er_save_manager/fixes/time_sync.py
+++ b/src/er_save_manager/fixes/time_sync.py
@@ -70,10 +70,8 @@ class TimeFix(BaseFix):
             time_bytes = BytesIO()
             time.write(time_bytes)
             time_data = time_bytes.getvalue()
-            # Calculate absolute offset
-            absolute_time_offset = slot.data_start + slot.time_offset
             save._raw_data[
-                absolute_time_offset : absolute_time_offset + len(time_data)
+                slot.time_offset : slot.time_offset + len(time_data)
             ] = time_data
 
             new_time = f"{hours:02d}:{minutes:02d}:{seconds:02d}"

--- a/src/er_save_manager/fixes/torrent.py
+++ b/src/er_save_manager/fixes/torrent.py
@@ -56,9 +56,9 @@ class TorrentFix(BaseFix):
             horse_bytes = BytesIO()
             horse.write(horse_bytes)
             horse_data = horse_bytes.getvalue()
-            save._raw_data[
-                slot.horse_offset : slot.horse_offset + len(horse_data)
-            ] = horse_data
+            save._raw_data[slot.horse_offset : slot.horse_offset + len(horse_data)] = (
+                horse_data
+            )
 
             return FixResult(
                 applied=True,

--- a/src/er_save_manager/fixes/torrent.py
+++ b/src/er_save_manager/fixes/torrent.py
@@ -56,10 +56,8 @@ class TorrentFix(BaseFix):
             horse_bytes = BytesIO()
             horse.write(horse_bytes)
             horse_data = horse_bytes.getvalue()
-            # Calculate absolute offset
-            absolute_horse_offset = slot.data_start + slot.horse_offset
             save._raw_data[
-                absolute_horse_offset : absolute_horse_offset + len(horse_data)
+                slot.horse_offset : slot.horse_offset + len(horse_data)
             ] = horse_data
 
             return FixResult(

--- a/src/er_save_manager/fixes/weather.py
+++ b/src/er_save_manager/fixes/weather.py
@@ -57,10 +57,8 @@ class WeatherFix(BaseFix):
             weather_bytes = BytesIO()
             weather.write(weather_bytes)
             weather_data = weather_bytes.getvalue()
-            # Calculate absolute offset
-            absolute_weather_offset = slot.data_start + slot.weather_offset
             save._raw_data[
-                absolute_weather_offset : absolute_weather_offset + len(weather_data)
+                slot.weather_offset : slot.weather_offset + len(weather_data)
             ] = weather_data
 
             return FixResult(

--- a/src/er_save_manager/parser/save.py
+++ b/src/er_save_manager/parser/save.py
@@ -447,6 +447,7 @@ class Save:
                 # Write to file
                 if hasattr(slot, "steamid_offset") and slot.steamid_offset > 0:
                     import struct
+
                     steamid_bytes = struct.pack("<Q", correct_steam_id)
                     self._raw_data[slot.steamid_offset : slot.steamid_offset + 8] = (
                         steamid_bytes
@@ -491,8 +492,7 @@ class Save:
                             time.write(time_bytes)
                             time_data = time_bytes.getvalue()
                             self._raw_data[
-                                slot.time_offset : slot.time_offset
-                                + len(time_data)
+                                slot.time_offset : slot.time_offset + len(time_data)
                             ] = time_data
                             fixes.append(
                                 f"Time set to {hours:02d}:{minutes:02d}:{seconds:02d}"
@@ -512,8 +512,7 @@ class Save:
                     weather_data = weather_bytes.getvalue()
                     # Calculate absolute offset
                     self._raw_data[
-                        slot.weather_offset : slot.weather_offset
-                        + len(weather_data)
+                        slot.weather_offset : slot.weather_offset + len(weather_data)
                     ] = weather_data
                     fixes.append(f"AreaId set to {weather.area_id}")
 

--- a/src/er_save_manager/parser/save.py
+++ b/src/er_save_manager/parser/save.py
@@ -428,10 +428,8 @@ class Save:
                     horse_bytes = BytesIO()
                     horse.write(horse_bytes)
                     horse_data = horse_bytes.getvalue()
-                    # Calculate absolute offset
-                    absolute_horse_offset = slot.data_start + slot.horse_offset
                     self._raw_data[
-                        absolute_horse_offset : absolute_horse_offset + len(horse_data)
+                        slot.horse_offset : slot.horse_offset + len(horse_data)
                     ] = horse_data
                     fixes.append(f"State changed to {horse.state.name}")
 
@@ -449,11 +447,8 @@ class Save:
                 # Write to file
                 if hasattr(slot, "steamid_offset") and slot.steamid_offset > 0:
                     import struct
-
-                    # Calculate absolute offset (steamid_offset is relative to data_start)
-                    absolute_offset = slot.data_start + slot.steamid_offset
                     steamid_bytes = struct.pack("<Q", correct_steam_id)
-                    self._raw_data[absolute_offset : absolute_offset + 8] = (
+                    self._raw_data[slot.steamid_offset : slot.steamid_offset + 8] = (
                         steamid_bytes
                     )
                     fixes.append(f"SteamId set to {correct_steam_id}")
@@ -495,10 +490,8 @@ class Save:
                             time_bytes = BytesIO()
                             time.write(time_bytes)
                             time_data = time_bytes.getvalue()
-                            # Calculate absolute offset
-                            absolute_time_offset = slot.data_start + slot.time_offset
                             self._raw_data[
-                                absolute_time_offset : absolute_time_offset
+                                slot.time_offset : slot.time_offset
                                 + len(time_data)
                             ] = time_data
                             fixes.append(
@@ -518,9 +511,8 @@ class Save:
                     weather.write(weather_bytes)
                     weather_data = weather_bytes.getvalue()
                     # Calculate absolute offset
-                    absolute_weather_offset = slot.data_start + slot.weather_offset
                     self._raw_data[
-                        absolute_weather_offset : absolute_weather_offset
+                        slot.weather_offset : slot.weather_offset
                         + len(weather_data)
                     ] = weather_data
                     fixes.append(f"AreaId set to {weather.area_id}")
@@ -554,12 +546,8 @@ class Save:
 
                 # Write back to raw data using the tracked offset
                 if hasattr(slot, "event_flags_offset") and slot.event_flags_offset > 0:
-                    # Calculate absolute offset
-                    absolute_event_flags_offset = (
-                        slot.data_start + slot.event_flags_offset
-                    )
                     self._raw_data[
-                        absolute_event_flags_offset : absolute_event_flags_offset
+                        slot.event_flags_offset : slot.event_flags_offset
                         + len(event_flags_mutable)
                     ] = event_flags_mutable
                 else:

--- a/src/er_save_manager/parser/user_data_x.py
+++ b/src/er_save_manager/parser/user_data_x.py
@@ -331,7 +331,6 @@ class UserDataX:
         obj.gestures = Gestures.read(f)
         obj.unlocked_regions = Regions.read(f)
         obj.horse_offset = f.tell()
-        obj.horse_offset = f.tell()
         obj.horse = RideGameData.read(f)
         obj.control_byte_maybe = struct.unpack("<B", f.read(1))[0]
         obj.blood_stain = BloodStain.read(f)
@@ -373,7 +372,7 @@ class UserDataX:
         obj.world_geom_man = WorldGeomMan.read(f)
         obj.world_geom_man2 = WorldGeomMan.read(f)
         obj.rend_man = RendMan.read(f)
-        obj.coordinates_offset = f.tell() - data_start
+        obj.coordinates_offset = f.tell()
         obj.player_coordinates = PlayerCoordinates.read(f)
 
         # 2 bytes padding after PlayerCoordinates

--- a/src/er_save_manager/ui/tabs/event_flags_tab.py
+++ b/src/er_save_manager/ui/tabs/event_flags_tab.py
@@ -579,7 +579,7 @@ class EventFlagsTab:
 
         if hasattr(slot, "event_flags_offset") and slot.event_flags_offset > 0:
             # Calculate absolute offset in the raw data
-            absolute_offset = slot.data_start + slot.event_flags_offset
+            absolute_offset = slot.event_flags_offset
             event_flags_size = 0x1BF99F  # 1,833,375 bytes
 
             # Write the modified event_flags buffer to raw_data
@@ -659,7 +659,7 @@ class EventFlagsTab:
                 slot = save_file.character_slots[self.current_slot]
 
                 if hasattr(slot, "event_flags_offset") and slot.event_flags_offset > 0:
-                    absolute_offset = slot.data_start + slot.event_flags_offset
+                    absolute_offset = slot.event_flags_offset
                     event_flags_size = 0x1BF99F
                     save_file._raw_data[
                         absolute_offset : absolute_offset + event_flags_size
@@ -904,7 +904,7 @@ class EventFlagsTab:
             slot = save_file.character_slots[self.current_slot]
 
             if hasattr(slot, "event_flags_offset") and slot.event_flags_offset > 0:
-                absolute_offset = slot.data_start + slot.event_flags_offset
+                absolute_offset = slot.event_flags_offset
                 event_flags_size = 0x1BF99F
                 save_file._raw_data[
                     absolute_offset : absolute_offset + event_flags_size
@@ -993,7 +993,7 @@ class EventFlagsTab:
             slot = save_file.character_slots[self.current_slot]
 
             if hasattr(slot, "event_flags_offset") and slot.event_flags_offset > 0:
-                absolute_offset = slot.data_start + slot.event_flags_offset
+                absolute_offset = slot.event_flags_offset
                 event_flags_size = 0x1BF99F
                 save_file._raw_data[
                     absolute_offset : absolute_offset + event_flags_size
@@ -1163,7 +1163,7 @@ class EventFlagsTab:
             # Write to raw data and save
             slot = save_file.character_slots[self.current_slot]
             if hasattr(slot, "event_flags_offset") and slot.event_flags_offset > 0:
-                absolute_offset = slot.data_start + slot.event_flags_offset
+                absolute_offset = slot.event_flags_offset
                 event_flags_size = 0x1BF99F
                 save_file._raw_data[
                     absolute_offset : absolute_offset + event_flags_size


### PR DESCRIPTION
fbcbdc3 converted the offsets from slot-relative to absolute, but only in the slot itself - [all](https://github.com/Hapfel1/er-save-manager/blob/e633be7986b6a114971e861b67e04ebf32859fd0/src/er_save_manager/editors/world_state.py#L134) [of](https://github.com/Hapfel1/er-save-manager/blob/e633be7986b6a114971e861b67e04ebf32859fd0/src/er_save_manager/fixes/dlc.py#L57) [the](https://github.com/Hapfel1/er-save-manager/blob/e633be7986b6a114971e861b67e04ebf32859fd0/src/er_save_manager/fixes/event_flags.py#L73) [other](https://github.com/Hapfel1/er-save-manager/blob/e633be7986b6a114971e861b67e04ebf32859fd0/src/er_save_manager/fixes/dlc.py#L57) [scripts](https://github.com/Hapfel1/er-save-manager/blob/e633be7986b6a114971e861b67e04ebf32859fd0/src/er_save_manager/fixes/steamid.py#L62) [in](https://github.com/Hapfel1/er-save-manager/blob/e633be7986b6a114971e861b67e04ebf32859fd0/src/er_save_manager/fixes/time_sync.py#L74) [the](https://github.com/Hapfel1/er-save-manager/blob/e633be7986b6a114971e861b67e04ebf32859fd0/src/er_save_manager/fixes/torrent.py#L60) [save](https://github.com/Hapfel1/er-save-manager/blob/e633be7986b6a114971e861b67e04ebf32859fd0/src/er_save_manager/fixes/weather.py#L61) [manager](https://github.com/Hapfel1/er-save-manager/blob/e633be7986b6a114971e861b67e04ebf32859fd0/src/er_save_manager/ui/tabs/event_flags_tab.py#L582) still expected it to have been removed and would re-add the slot data offset back in, corrupting the offset and trashing the save slot. This commit removes the redundant offset addition from the other scripts for consistency, and to prevent the save slot from being trashed. The deep scanner and teleport scripts are unmodified, as they are using this data correctly.