### PR TITLE
🚀 Release: ER Save Manager v1.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,33 @@
 > A comprehensive changelog for the Elden Ring Save Manager application.
 > All notable changes to this project are documented here.
 
+## 📦 Release 1.3.3
+**Released:** June 01, 2026
+
+
+### 🔧 Bug Fixes
+
+- Preserve global array header when writing to preset slot 0 ([d78675f](https://github.com/Hapfel1/er-save-manager/commit/d78675f2f5381ae3c57557d8f3bd6acc192dbef4))
+
+- Added mising Convergence Item, Putrid Key ([0a88729](https://github.com/Hapfel1/er-save-manager/commit/0a88729158aa2439d189af2ac8733fbf35bb68cf))
+
+- Route key items to key_items[] in inventory ops ([5c99b64](https://github.com/Hapfel1/er-save-manager/commit/5c99b6488ad0ba0eb650d436032836db5aaaa634))
+
+
+
+### 🎨 User Interface
+
+- Fix scroll bar bug in Icon Browser ([196da49](https://github.com/Hapfel1/er-save-manager/commit/196da49a1176fdf0e1bd5ca1c7df3d186e7ada0d))
+
+
+
+### 📦 Dependencies
+
+- Bump the github-actions group with 2 updates `[deps]` ([93bf07e](https://github.com/Hapfel1/er-save-manager/commit/93bf07e25a4ffe760c6a2ae1c09fb202731af842))
+
+
+
+---
 ## 📦 Release 1.3.2
 **Released:** May 29, 2026
 
@@ -963,6 +990,7 @@ implementation) ([77f66e6](https://github.com/Hapfel1/er-save-manager/commit/77f
 
 
 ---
+[1.3.3]: https://github.com/Hapfel1/er-save-manager/compare/v1.3.2..v1.3.3
 [1.3.2]: https://github.com/Hapfel1/er-save-manager/compare/v1.3.1..v1.3.2
 [1.3.1]: https://github.com/Hapfel1/er-save-manager/compare/v1.3.0..v1.3.1
 [1.3.0]: https://github.com/Hapfel1/er-save-manager/compare/v1.2.2..v1.3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "er-save-manager"
-version = "1.3.2"
+version = "1.3.3"
 description = "Elden Ring Save File Editor, Backup Manager, and Corruption Fixer"
 readme = "README.md"
 license = "MIT"

--- a/resources/app.manifest
+++ b/resources/app.manifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
   <assemblyIdentity
-    version="1.3.2.0"
+    version="1.3.3.0"
     processorArchitecture="x86"
     name="ER.Save.Manager"
     type="win32"

--- a/resources/version.txt
+++ b/resources/version.txt
@@ -1,6 +1,6 @@
-version=1.3.2.0
-file_version=1.3.2.0
-product_version=1.3.2.0
+version=1.3.3.0
+file_version=1.3.3.0
+product_version=1.3.3.0
 company=ER Save Manager Contributors
 description=Elden Ring Save File Manager
 product=ER Save Manager

--- a/src/er_save_manager/__init__.py
+++ b/src/er_save_manager/__init__.py
@@ -26,4 +26,4 @@ __all__ = [
     "VersionChecker",
 ]
 
-__version__ = "1.3.2"
+__version__ = "1.3.3"

--- a/uv.lock
+++ b/uv.lock
@@ -325,7 +325,7 @@ wheels = [
 
 [[package]]
 name = "er-save-manager"
-version = "1.3.2"
+version = "1.3.3"
 source = { editable = "." }
 dependencies = [
     { name = "certifi" },


### PR DESCRIPTION
## 🚧 UNRELEASED

**This release is still under development.**
Changes in this PR will be included in the final release once merged.

---

## 📦 Release 1.3.3
**Released:** June 01, 2026


### 🔧 Bug Fixes

- Preserve global array header when writing to preset slot 0 ([d78675f](https://github.com/Hapfel1/er-save-manager/commit/d78675f2f5381ae3c57557d8f3bd6acc192dbef4))

- Added mising Convergence Item, Putrid Key ([0a88729](https://github.com/Hapfel1/er-save-manager/commit/0a88729158aa2439d189af2ac8733fbf35bb68cf))

- Route key items to key_items[] in inventory ops ([5c99b64](https://github.com/Hapfel1/er-save-manager/commit/5c99b6488ad0ba0eb650d436032836db5aaaa634))



### 🎨 User Interface

- Fix scroll bar bug in Icon Browser ([196da49](https://github.com/Hapfel1/er-save-manager/commit/196da49a1176fdf0e1bd5ca1c7df3d186e7ada0d))



### 📦 Dependencies

- Bump the github-actions group with 2 updates `[deps]` ([93bf07e](https://github.com/Hapfel1/er-save-manager/commit/93bf07e25a4ffe760c6a2ae1c09fb202731af842))



---