### PR TITLE
fix(DSR): correct event flag base offset, add level recalc, flag look…

### DIFF
--- a/src/er_save_manager/games/DSR/editor_tab.py
+++ b/src/er_save_manager/games/DSR/editor_tab.py
@@ -66,6 +66,8 @@ class DSREditorTab:
         self._covenant_var = tk.StringVar(value=_COVENANTS[0])
         self._ng_var = tk.StringVar(value="0")
         self._playtime_var = tk.StringVar(value="--")
+        # Starting class index at last load; used for level recalc
+        self._loaded_class_idx: int = 0
 
     def setup_ui(self) -> None:
         # Outer wrapper fills parent - fixes content being pushed down on CTkTabview frames
@@ -143,6 +145,7 @@ class DSREditorTab:
             )
             var = tk.StringVar(value="1")
             self._stat_vars[key] = var
+            var.trace_add("write", lambda *_: self._recalc_level())
             ctk.CTkEntry(ag, textvariable=var, width=120).grid(
                 row=i, column=1, padx=5, pady=5
             )
@@ -173,7 +176,7 @@ class DSREditorTab:
 
         ctk.CTkLabel(
             frame,
-            text="Saving VIT updates derived max HP. Saving END updates max Stamina.",
+            text="Saving VIT updates derived max HP. Saving END updates max Stamina. Level is recalculated from stats automatically.",
             font=("Segoe UI", 10),
             text_color=("gray40", "gray70"),
         ).pack(anchor="w", padx=15, pady=(4, 0))
@@ -284,6 +287,7 @@ class DSREditorTab:
             return
         for key in ("vit", "atn", "end", "str", "dex", "int", "fth", "res"):
             self._stat_vars[key].set(str(char.get_stat(key)))
+        self._loaded_class_idx = int(char.player_class)
         self._stat_vars["level"].set(str(char.level))
         self._stat_vars["souls"].set(str(char.souls))
         self._stat_vars["humanity"].set(str(char.humanity))
@@ -298,6 +302,28 @@ class DSREditorTab:
         m = int((char.play_seconds % 3600) // 60)
         s = int(char.play_seconds % 60)
         self._playtime_var.set(f"{h}h {m:02d}m {s:02d}s")
+
+    def _recalc_level(self) -> None:
+        """Recalculate and update the level field from current stat inputs."""
+        try:
+            from er_save_manager.games.DSR.save import calc_level_from_stats
+        except ImportError:
+            return
+        try:
+            vit = int(self._stat_vars["vit"].get())
+            atn = int(self._stat_vars["atn"].get())
+            end = int(self._stat_vars["end"].get())
+            str_ = int(self._stat_vars["str"].get())
+            dex = int(self._stat_vars["dex"].get())
+            int_ = int(self._stat_vars["int"].get())
+            fth = int(self._stat_vars["fth"].get())
+            res = int(self._stat_vars["res"].get())
+        except ValueError:
+            return
+        lvl = calc_level_from_stats(
+            self._loaded_class_idx, vit, atn, end, str_, dex, int_, fth, res
+        )
+        self._stat_vars["level"].set(str(max(1, lvl)))
 
     # --- Apply ---------------------------------------------------------------- #
 

--- a/src/er_save_manager/games/DSR/event_flags_tab.py
+++ b/src/er_save_manager/games/DSR/event_flags_tab.py
@@ -71,6 +71,8 @@ class DSREventFlagsTab:
         self._current_slot = 0
         self._npc_built = False
         self._world_built = False
+        self._lookup_id_var: tk.StringVar | None = None
+        self._lookup_result_var: tk.StringVar | None = None
 
     def setup_ui(self) -> None:
         outer = ctk.CTkFrame(self.parent, corner_radius=12)
@@ -103,6 +105,7 @@ class DSREventFlagsTab:
 
         self._npc_parent = self._tabs.add("NPC States")
         self._world_parent = self._tabs.add("World Flags")
+        self._lookup_parent = self._tabs.add("Flag Lookup")
 
         for p, t in [
             (self._npc_parent, "Load a character to view NPC state flags."),
@@ -110,6 +113,7 @@ class DSREventFlagsTab:
         ]:
             ctk.CTkLabel(p, text=t, text_color=("gray50", "gray60")).pack(pady=40)
 
+        self._build_lookup_ui()
         _apply_treeview_style()
 
     def _on_tab_change(self) -> None:
@@ -412,6 +416,91 @@ class DSREventFlagsTab:
             )
         except Exception as exc:
             CTkMessageBox.showerror("Save Failed", str(exc), parent=self.parent)
+
+    # --- Flag Lookup ---------------------------------------------------------- #
+
+    def _build_lookup_ui(self) -> None:
+        outer = ctk.CTkFrame(self._lookup_parent, fg_color="transparent")
+        outer.pack(fill="both", expand=True, padx=12, pady=10)
+
+        ctk.CTkLabel(
+            outer,
+            text="Read or write any event flag by numeric ID.",
+            font=("Segoe UI", 10),
+            text_color=("gray40", "gray70"),
+        ).pack(anchor="w", pady=(0, 8))
+
+        input_row = ctk.CTkFrame(outer, fg_color="transparent")
+        input_row.pack(fill="x", pady=(0, 6))
+
+        ctk.CTkLabel(input_row, text="Flag ID:").pack(side="left", padx=(0, 6))
+        self._lookup_id_var = tk.StringVar()
+        ctk.CTkEntry(
+            input_row,
+            textvariable=self._lookup_id_var,
+            width=120,
+            placeholder_text="e.g. 11010000",
+        ).pack(side="left", padx=(0, 8))
+        ctk.CTkButton(input_row, text="Read", command=self._lookup_read, width=70).pack(
+            side="left", padx=(0, 4)
+        )
+        ctk.CTkButton(
+            input_row, text="Set ON", command=lambda: self._lookup_write(True), width=75
+        ).pack(side="left", padx=(0, 4))
+        ctk.CTkButton(
+            input_row,
+            text="Set OFF",
+            command=lambda: self._lookup_write(False),
+            width=75,
+        ).pack(side="left")
+
+        self._lookup_result_var = tk.StringVar(value="")
+        ctk.CTkLabel(
+            outer,
+            textvariable=self._lookup_result_var,
+            font=("Consolas", 11),
+            anchor="w",
+        ).pack(anchor="w", pady=(6, 0))
+
+    def _lookup_read(self) -> None:
+        _, _, char = self._get_char()
+        if char is None:
+            self._lookup_result_var.set("No character loaded.")
+            return
+        try:
+            fid = int(self._lookup_id_var.get().strip())
+        except ValueError:
+            self._lookup_result_var.set("Invalid flag ID.")
+            return
+        try:
+            state = char.get_flag(fid)
+            self._lookup_result_var.set(
+                f"Flag {fid}  ->  {'ON (1)' if state else 'OFF (0)'}"
+            )
+        except Exception as exc:
+            self._lookup_result_var.set(f"Error: {exc}")
+
+    def _lookup_write(self, value: bool) -> None:
+        save, save_path, char = self._get_char()
+        if char is None:
+            self._lookup_result_var.set("No character loaded.")
+            return
+        try:
+            fid = int(self._lookup_id_var.get().strip())
+        except ValueError:
+            self._lookup_result_var.set("Invalid flag ID.")
+            return
+        try:
+            char.set_flag(fid, value)
+            _backup_and_save(
+                save, save_path, f"flag_{fid}_slot_{self._current_slot + 1}"
+            )
+            self._lookup_result_var.set(
+                f"Flag {fid}  ->  set to {'ON (1)' if value else 'OFF (0)'}. Backup created."
+            )
+            self._show_toast(f"Flag {fid} -> {'ON' if value else 'OFF'}.")
+        except Exception as exc:
+            self._lookup_result_var.set(f"Error: {exc}")
 
     # --- Refresh / helpers ---------------------------------------------------- #
 

--- a/src/er_save_manager/games/DSR/save.py
+++ b/src/er_save_manager/games/DSR/save.py
@@ -277,6 +277,48 @@ ANCHOR_BONFIRE_2 = 0x6C
 ANCHOR_BONFIRE_3 = 0x6D
 ANCHOR_BONFIRE_WARP = 0xAE
 
+# Event flags start immediately after the 16-byte Pattern1 marker.
+# Encoding: byte = flags_base + flag_id // 8, bit = flag_id % 8 (LSB-first).
+PATTERN1_LEN = 16
+
+# Starting stats per class: (base_level, vit, atn, end, str, dex, int, fth, res)
+# Used to recalculate total level when individual stats are edited.
+_CLASS_BASE_STATS: dict[int, tuple[int, ...]] = {
+    0: (4, 11, 8, 12, 13, 13, 9, 9, 11),  # Warrior
+    1: (5, 14, 10, 10, 11, 11, 9, 11, 10),  # Knight
+    2: (3, 10, 11, 10, 10, 14, 11, 8, 10),  # Wanderer
+    3: (5, 9, 11, 9, 9, 15, 12, 11, 10),  # Thief
+    4: (4, 12, 8, 14, 14, 9, 8, 10, 11),  # Bandit
+    5: (4, 11, 9, 11, 12, 14, 9, 8, 10),  # Hunter
+    6: (3, 8, 15, 8, 9, 11, 15, 8, 8),  # Sorcerer
+    7: (1, 10, 12, 11, 12, 9, 10, 8, 11),  # Pyromancer
+    8: (2, 11, 11, 9, 12, 8, 8, 14, 11),  # Cleric
+    9: (1, 11, 11, 11, 11, 11, 11, 11, 11),  # Deprived
+}
+
+
+def calc_level_from_stats(
+    player_class: int,
+    vit: int,
+    atn: int,
+    end: int,
+    str_: int,
+    dex: int,
+    int_: int,
+    fth: int,
+    res: int,
+) -> int:
+    """
+    Compute total SL from current stats and starting class.
+    SL = class_base_level + sum(current_stats) - sum(class_base_stats)
+    """
+    base = _CLASS_BASE_STATS.get(player_class, _CLASS_BASE_STATS[9])
+    base_level, *base_stats = base
+    current_sum = vit + atn + end + str_ + dex + int_ + fth + res
+    base_sum = sum(base_stats)
+    return base_level + (current_sum - base_sum)
+
+
 # VIT -> max HP lookup (game does not recalculate on load; must be set manually)
 VIT_TO_HP: dict[int, int] = {
     1: 400,
@@ -1096,32 +1138,31 @@ class DSRCharacter:
         """
         Read a game event flag.
 
-        Encoding: byte_offset = anchor + flag_id // 8, bit = flag_id % 8.
-        Covers all global flags (2-17), NPC states (1000-1900), gesture flags
-        (280-288), and utility flags up to ID ~2,124,719.
-        Map-specific flags (11xxxxxx, 50xxxxxx) are out of range.
+        Flags are stored immediately after the 16-byte Pattern1 marker.
+        Encoding: byte = anchor + PATTERN1_LEN + flag_id // 8, bit = flag_id % 8 (LSB-first).
+        Covers boss kills (2-17), NPC states, gesture flags, and utility flags.
         """
         anchor = self._find_pattern1()
         if anchor < 0:
             raise ValueError("Pattern1 not found")
-        off = anchor + flag_id // 8
+        off = anchor + PATTERN1_LEN + flag_id // 8
         if off >= len(self._data):
             raise IndexError(
-                f"Flag {flag_id} out of accessible range "
-                f"(needs anchor+{flag_id // 8:#x}, available to anchor+{len(self._data) - anchor:#x})"
+                f"Flag {flag_id} out of range "
+                f"(needs anchor+{PATTERN1_LEN + flag_id // 8:#x})"
             )
         return bool((self._data[off] >> (flag_id % 8)) & 1)
 
     def set_flag(self, flag_id: int, value: bool) -> None:
-        """Write a game event flag. See get_flag for encoding and range details."""
+        """Write a game event flag. See get_flag for encoding details."""
         anchor = self._find_pattern1()
         if anchor < 0:
             raise ValueError("Pattern1 not found")
-        off = anchor + flag_id // 8
+        off = anchor + PATTERN1_LEN + flag_id // 8
         if off >= len(self._data):
             raise IndexError(
-                f"Flag {flag_id} out of accessible range "
-                f"(needs anchor+{flag_id // 8:#x}, available to anchor+{len(self._data) - anchor:#x})"
+                f"Flag {flag_id} out of range "
+                f"(needs anchor+{PATTERN1_LEN + flag_id // 8:#x})"
             )
         if value:
             self._data[off] |= 1 << (flag_id % 8)


### PR DESCRIPTION
…up tab

- get_flag/set_flag were reading from the Pattern1 marker bytes itself (FF FF FF FF 00 00 00 00...), causing flags 0-7 to always read as set. Offset now starts after the 16-byte pattern: anchor + PATTERN1_LEN + id//8.
- Add calc_level_from_stats() with class base stat table for all 10 classes. Stats editor now auto-recalculates SL on any stat change.
- Add Flag Lookup sub-tab: read or write any flag by numeric ID.