### PR TITLE
🚀 Release: ER Save Manager v1.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 > A comprehensive changelog for the Elden Ring Save Manager application.
 > All notable changes to this project are documented here.
 
+## 📦 Release 1.4.2
+**Released:** June 15, 2026
+
+
+### 📦 Dependencies
+
+- Bump taiki-e/install-action in the github-actions group `[deps]` ([766486c](https://github.com/Hapfel1/er-save-manager/commit/766486c604394572e3bcaabf3a08bef902ecc418))
+
+
+
+---
 ## 📦 Release 1.4.1
 **Released:** June 09, 2026
 
@@ -1075,6 +1086,7 @@ implementation) ([77f66e6](https://github.com/Hapfel1/er-save-manager/commit/77f
 
 
 ---
+[1.4.2]: https://github.com/Hapfel1/er-save-manager/compare/v1.4.1..v1.4.2
 [1.4.1]: https://github.com/Hapfel1/er-save-manager/compare/v1.4.0..v1.4.1
 [1.4.0]: https://github.com/Hapfel1/er-save-manager/compare/v1.3.2..v1.4.0
 [1.3.2]: https://github.com/Hapfel1/er-save-manager/compare/v1.3.1..v1.3.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "er-save-manager"
-version = "1.4.1"
+version = "1.4.2"
 description = "Elden Ring Save File Editor, Backup Manager, and Corruption Fixer"
 readme = "README.md"
 license = "MIT"

--- a/resources/app.manifest
+++ b/resources/app.manifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
   <assemblyIdentity
-    version="1.4.1.0"
+    version="1.4.2.0"
     processorArchitecture="x86"
     name="ER.Save.Manager"
     type="win32"

--- a/resources/version.txt
+++ b/resources/version.txt
@@ -1,6 +1,6 @@
-version=1.4.1.0
-file_version=1.4.1.0
-product_version=1.4.1.0
+version=1.4.2.0
+file_version=1.4.2.0
+product_version=1.4.2.0
 company=ER Save Manager Contributors
 description=Elden Ring Save File Manager
 product=ER Save Manager

--- a/src/er_save_manager/__init__.py
+++ b/src/er_save_manager/__init__.py
@@ -26,4 +26,4 @@ __all__ = [
     "VersionChecker",
 ]
 
-__version__ = "1.4.1"
+__version__ = "1.4.2"

--- a/uv.lock
+++ b/uv.lock
@@ -325,7 +325,7 @@ wheels = [
 
 [[package]]
 name = "er-save-manager"
-version = "1.4.1"
+version = "1.4.2"
 source = { editable = "." }
 dependencies = [
     { name = "certifi" },


### PR DESCRIPTION
## 🚧 UNRELEASED

**This release is still under development.**
Changes in this PR will be included in the final release once merged.

---

## 📦 Release 1.4.2
**Released:** June 15, 2026


### 📦 Dependencies

- Bump taiki-e/install-action in the github-actions group `[deps]` ([766486c](https://github.com/Hapfel1/er-save-manager/commit/766486c604394572e3bcaabf3a08bef902ecc418))



---