### PR TITLE
🚀 Release: ER Save Manager v1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,59 @@
 > A comprehensive changelog for the Elden Ring Save Manager application.
 > All notable changes to this project are documented here.
 
+## 📦 Release 1.5.1
+**Released:** June 23, 2026
+
+
+### 🔧 Bug Fixes
+
+- Update player_game_data_offset after gaitem shift and bump mm level on weapon spawn ([9f45343](https://github.com/Hapfel1/er-save-manager/commit/9f45343cd8b5be206a1fae22414eb608169350ee))
+
+- Auto-adjust matchmaking level on weapon removal, remove manual set button ([a8d1a20](https://github.com/Hapfel1/er-save-manager/commit/a8d1a20aa6da0b69703f5017b1cba0f6a5288d36))
+
+- Added missed Convergence Item, Warding Remnant ([70fb917](https://github.com/Hapfel1/er-save-manager/commit/70fb9174eb358d568002e3f366485b2ffdc4d7b7))
+
+- Add boss status dialog, fix bell bearing NG+ flags, fix search debounce (closes #189) ([ed0afb2](https://github.com/Hapfel1/er-save-manager/commit/ed0afb2422e89c427f80e59ecacd8f552b1e861e))
+
+- Prevent integer overflow from corrupted acquisition indices `[inventory]` ([5c4f935](https://github.com/Hapfel1/er-save-manager/commit/5c4f93559df8b0623a4a1a6815972112aac6b9eb))
+
+- Adjust UI spacing and resolve loadout file path `[inventory]` ([19aa279](https://github.com/Hapfel1/er-save-manager/commit/19aa279dadb2f6c8e147455340ac79d871a3844f))
+
+
+
+### 🎨 User Interface
+
+- Made CSNetMan.bin replace button show permanently ([2486af1](https://github.com/Hapfel1/er-save-manager/commit/2486af1d4590d0dc298e24b764eb6361b06ed2b0))
+
+- Made Message about CsNetMan more clear ([902dfdb](https://github.com/Hapfel1/er-save-manager/commit/902dfdba6c2fa1aa27dacbc986db068a051dfd92))
+
+- Add Debug warped face button ([a43e5df](https://github.com/Hapfel1/er-save-manager/commit/a43e5dfa46aa66c9b0632bad5f5284d53e23f17b))
+
+- Add loadout manager, batch spawning, and smart stacking `[inventory]` ([10d3f93](https://github.com/Hapfel1/er-save-manager/commit/10d3f9300cc62897b4f757b6872f698d174925ef))
+
+- Replace warped face button with slider dialog for secondary face deformation ([b13fbe7](https://github.com/Hapfel1/er-save-manager/commit/b13fbe767a57f131f812e1bc37896ea9c465ca5c))
+
+
+
+### ♻️ Code Refactoring
+
+- Remove CSNetMan replace button toggle setting ([92744b0](https://github.com/Hapfel1/er-save-manager/commit/92744b046a41219369a8c7c6f859581148ae2420))
+
+
+
+### 📦 Dependencies
+
+- Bump the github-actions group with 3 updates `[deps]` ([ea4b49e](https://github.com/Hapfel1/er-save-manager/commit/ea4b49ea31f40e5fca10ff0939d9c5d8c5c24f6e))
+
+
+
+### 🧹 Maintenance
+
+- Migrate nexusmods upload action to v1.0.0-beta.8 ([10d8f67](https://github.com/Hapfel1/er-save-manager/commit/10d8f67e5ddabc916eb276cbbf3128c98165a46d))
+
+
+
+---
 ## 📦 Release 1.5.0
 **Released:** June 18, 2026
 
@@ -1127,6 +1180,7 @@ implementation) ([77f66e6](https://github.com/Hapfel1/er-save-manager/commit/77f
 
 
 ---
+[1.5.1]: https://github.com/Hapfel1/er-save-manager/compare/v1.5.0..v1.5.1
 [1.5.0]: https://github.com/Hapfel1/er-save-manager/compare/v1.4.1..v1.5.0
 [1.4.1]: https://github.com/Hapfel1/er-save-manager/compare/v1.4.0..v1.4.1
 [1.4.0]: https://github.com/Hapfel1/er-save-manager/compare/v1.3.2..v1.4.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "er-save-manager"
-version = "1.5.0"
+version = "1.5.1"
 description = "Elden Ring Save File Editor, Backup Manager, and Corruption Fixer"
 readme = "README.md"
 license = "MIT"

--- a/resources/app.manifest
+++ b/resources/app.manifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
   <assemblyIdentity
-    version="1.5.0.0"
+    version="1.5.1.0"
     processorArchitecture="x86"
     name="ER.Save.Manager"
     type="win32"

--- a/resources/version.txt
+++ b/resources/version.txt
@@ -1,6 +1,6 @@
-version=1.5.0.0
-file_version=1.5.0.0
-product_version=1.5.0.0
+version=1.5.1.0
+file_version=1.5.1.0
+product_version=1.5.1.0
 company=ER Save Manager Contributors
 description=Elden Ring Save File Manager
 product=ER Save Manager

--- a/src/er_save_manager/__init__.py
+++ b/src/er_save_manager/__init__.py
@@ -26,4 +26,4 @@ __all__ = [
     "VersionChecker",
 ]
 
-__version__ = "1.5.0"
+__version__ = "1.5.1"

--- a/uv.lock
+++ b/uv.lock
@@ -325,7 +325,7 @@ wheels = [
 
 [[package]]
 name = "er-save-manager"
-version = "1.5.0"
+version = "1.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "certifi" },


### PR DESCRIPTION
## 🚧 UNRELEASED

**This release is still under development.**
Changes in this PR will be included in the final release once merged.

---

## 📦 Release 1.5.1
**Released:** June 23, 2026


### 🔧 Bug Fixes

- Update player_game_data_offset after gaitem shift and bump mm level on weapon spawn ([9f45343](https://github.com/Hapfel1/er-save-manager/commit/9f45343cd8b5be206a1fae22414eb608169350ee))

- Auto-adjust matchmaking level on weapon removal, remove manual set button ([a8d1a20](https://github.com/Hapfel1/er-save-manager/commit/a8d1a20aa6da0b69703f5017b1cba0f6a5288d36))

- Added missed Convergence Item, Warding Remnant ([70fb917](https://github.com/Hapfel1/er-save-manager/commit/70fb9174eb358d568002e3f366485b2ffdc4d7b7))

- Add boss status dialog, fix bell bearing NG+ flags, fix search debounce (closes #189) ([ed0afb2](https://github.com/Hapfel1/er-save-manager/commit/ed0afb2422e89c427f80e59ecacd8f552b1e861e))

- Prevent integer overflow from corrupted acquisition indices `[inventory]` ([5c4f935](https://github.com/Hapfel1/er-save-manager/commit/5c4f93559df8b0623a4a1a6815972112aac6b9eb))

- Adjust UI spacing and resolve loadout file path `[inventory]` ([19aa279](https://github.com/Hapfel1/er-save-manager/commit/19aa279dadb2f6c8e147455340ac79d871a3844f))



### 🎨 User Interface

- Made CSNetMan.bin replace button show permanently ([2486af1](https://github.com/Hapfel1/er-save-manager/commit/2486af1d4590d0dc298e24b764eb6361b06ed2b0))

- Made Message about CsNetMan more clear ([902dfdb](https://github.com/Hapfel1/er-save-manager/commit/902dfdba6c2fa1aa27dacbc986db068a051dfd92))

- Add Debug warped face button ([a43e5df](https://github.com/Hapfel1/er-save-manager/commit/a43e5dfa46aa66c9b0632bad5f5284d53e23f17b))

- Add loadout manager, batch spawning, and smart stacking `[inventory]` ([10d3f93](https://github.com/Hapfel1/er-save-manager/commit/10d3f9300cc62897b4f757b6872f698d174925ef))

- Replace warped face button with slider dialog for secondary face deformation ([b13fbe7](https://github.com/Hapfel1/er-save-manager/commit/b13fbe767a57f131f812e1bc37896ea9c465ca5c))



### ♻️ Code Refactoring

- Remove CSNetMan replace button toggle setting ([92744b0](https://github.com/Hapfel1/er-save-manager/commit/92744b046a41219369a8c7c6f859581148ae2420))



### 📦 Dependencies

- Bump the github-actions group with 3 updates `[deps]` ([ea4b49e](https://github.com/Hapfel1/er-save-manager/commit/ea4b49ea31f40e5fca10ff0939d9c5d8c5c24f6e))



### 🧹 Maintenance

- Migrate nexusmods upload action to v1.0.0-beta.8 ([10d8f67](https://github.com/Hapfel1/er-save-manager/commit/10d8f67e5ddabc916eb276cbbf3128c98165a46d))



---