### PR TITLE
🚀 Release: ER Save Manager v1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,45 @@
 > A comprehensive changelog for the Elden Ring Save Manager application.
 > All notable changes to this project are documented here.
 
+## 📦 Release 1.5.2
+**Released:** June 29, 2026
+
+
+### 🔧 Bug Fixes
+
+- Correct consumable stack location and convergence upgrade caps (#193) ([ffe3465](https://github.com/Hapfel1/er-save-manager/commit/ffe34656fc52e868db4a312de6c88477c2387753))
+
+- Correct inventory counter updates for key items in add/remove ([e85e039](https://github.com/Hapfel1/er-save-manager/commit/e85e039e280c829b5bfacfd0e295866af0787f16))
+
+- Trigger auto-backup on every game launch, not once per session `[backup]` ([2ee638d](https://github.com/Hapfel1/er-save-manager/commit/2ee638d81dde2d5b92010aa5b21622cd414550ed))
+
+- Rename invasion regions to unlocked regions ([2e9ed01](https://github.com/Hapfel1/er-save-manager/commit/2e9ed010e0ba6a6a60fdb1b077623a1959485c5e))
+
+- Detect and repair corrupted inventory item counters in character details ([fe5aa9c](https://github.com/Hapfel1/er-save-manager/commit/fe5aa9c48d238bd3bb32e8299cdceee876ef8d72))
+
+- Add Event Flag mapping for maps and ashes of war ([6ceba63](https://github.com/Hapfel1/er-save-manager/commit/6ceba634e8d19c8843648d5284388ad88ab5a9eb))
+
+
+
+### 🎨 User Interface
+
+- Add Video Guide button for Ghost's video guide ([74b6f1e](https://github.com/Hapfel1/er-save-manager/commit/74b6f1ec39493a91525cd1843ee0c87b9cda825b))
+
+
+
+### 📦 Dependencies
+
+- Bump the github-actions group with 2 updates `[deps]` ([91cc328](https://github.com/Hapfel1/er-save-manager/commit/91cc328aa490335a822f45aba863c78ba70635ee))
+
+
+
+### Data
+
+- Migrate icon storage from zip to sqlite, fix nexus mods quarantine ([10d42eb](https://github.com/Hapfel1/er-save-manager/commit/10d42eb7e64d403d2e0dcba3d603a44cf629b5a2))
+
+
+
+---
 ## 📦 Release 1.5.1
 **Released:** June 23, 2026
 
@@ -1180,6 +1219,7 @@ implementation) ([77f66e6](https://github.com/Hapfel1/er-save-manager/commit/77f
 
 
 ---
+[1.5.2]: https://github.com/Hapfel1/er-save-manager/compare/v1.5.1..v1.5.2
 [1.5.1]: https://github.com/Hapfel1/er-save-manager/compare/v1.5.0..v1.5.1
 [1.5.0]: https://github.com/Hapfel1/er-save-manager/compare/v1.4.1..v1.5.0
 [1.4.1]: https://github.com/Hapfel1/er-save-manager/compare/v1.4.0..v1.4.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "er-save-manager"
-version = "1.5.1"
+version = "1.5.2"
 description = "Elden Ring Save File Editor, Backup Manager, and Corruption Fixer"
 readme = "README.md"
 license = "MIT"

--- a/resources/app.manifest
+++ b/resources/app.manifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
   <assemblyIdentity
-    version="1.5.1.0"
+    version="1.5.2.0"
     processorArchitecture="x86"
     name="ER.Save.Manager"
     type="win32"

--- a/resources/version.txt
+++ b/resources/version.txt
@@ -1,6 +1,6 @@
-version=1.5.1.0
-file_version=1.5.1.0
-product_version=1.5.1.0
+version=1.5.2.0
+file_version=1.5.2.0
+product_version=1.5.2.0
 company=ER Save Manager Contributors
 description=Elden Ring Save File Manager
 product=ER Save Manager

--- a/src/er_save_manager/__init__.py
+++ b/src/er_save_manager/__init__.py
@@ -26,4 +26,4 @@ __all__ = [
     "VersionChecker",
 ]
 
-__version__ = "1.5.1"
+__version__ = "1.5.2"

--- a/uv.lock
+++ b/uv.lock
@@ -303,8 +303,8 @@ name = "dmgbuild"
 version = "1.6.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ds-store", marker = "(python_full_version >= '3.14' and platform_machine == 'ARM64' and sys_platform == 'win32') or (platform_machine != 'aarch64' and platform_machine != 'armv7l' and platform_machine != 'i686' and platform_machine != 'ppc64le' and platform_machine != 's390x' and platform_machine != 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and sys_platform != 'win32')" },
-    { name = "mac-alias", marker = "(python_full_version >= '3.14' and platform_machine == 'ARM64' and sys_platform == 'win32') or (platform_machine != 'aarch64' and platform_machine != 'armv7l' and platform_machine != 'i686' and platform_machine != 'ppc64le' and platform_machine != 's390x' and platform_machine != 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and sys_platform != 'win32')" },
+    { name = "ds-store" },
+    { name = "mac-alias" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a7/a5/f4dbd63c96902de8f2427a82518aaeedac0006587409294e55a14e45f367/dmgbuild-1.6.7.tar.gz", hash = "sha256:676b17acd448899f6d4a83b2184e0657480444ecb6ac9c4922889efad9e5dbfb", size = 36938, upload-time = "2026-01-15T23:13:43.779Z" }
 wheels = [
@@ -316,7 +316,7 @@ name = "ds-store"
 version = "1.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "mac-alias", marker = "(python_full_version >= '3.14' and platform_machine == 'ARM64' and sys_platform == 'win32') or (platform_machine != 'aarch64' and platform_machine != 'armv7l' and platform_machine != 'i686' and platform_machine != 'ppc64le' and platform_machine != 's390x' and platform_machine != 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and sys_platform != 'win32')" },
+    { name = "mac-alias" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e9/11/971e423750b219ec3f3a7f27dfb9bd74aef3d3fdfee6cc7df10a0217b5cd/ds_store-1.3.2.tar.gz", hash = "sha256:e4da49df901123481a85b9250945f2aac054a0f0c29352cd2cc858c536cdd364", size = 26574, upload-time = "2025-12-04T00:52:46.178Z" }
 wheels = [
@@ -325,7 +325,7 @@ wheels = [
 
 [[package]]
 name = "er-save-manager"
-version = "1.5.1"
+version = "1.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "certifi" },
@@ -554,7 +554,7 @@ name = "macholib"
 version = "1.16.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "altgraph", marker = "(python_full_version >= '3.14' and platform_machine == 'ARM64' and sys_platform == 'win32') or (platform_machine != 'aarch64' and platform_machine != 'armv7l' and platform_machine != 'i686' and platform_machine != 'ppc64le' and platform_machine != 's390x' and platform_machine != 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and sys_platform != 'win32')" },
+    { name = "altgraph" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/10/2f/97589876ea967487978071c9042518d28b958d87b17dceb7cdc1d881f963/macholib-1.16.4.tar.gz", hash = "sha256:f408c93ab2e995cd2c46e34fe328b130404be143469e41bc366c807448979362", size = 59427, upload-time = "2025-11-22T08:28:38.373Z" }
 wheels = [


### PR DESCRIPTION
## 🚧 UNRELEASED

**This release is still under development.**
Changes in this PR will be included in the final release once merged.

---

## 📦 Release 1.5.2
**Released:** June 29, 2026


### 🔧 Bug Fixes

- Correct consumable stack location and convergence upgrade caps (#193) ([ffe3465](https://github.com/Hapfel1/er-save-manager/commit/ffe34656fc52e868db4a312de6c88477c2387753))

- Correct inventory counter updates for key items in add/remove ([e85e039](https://github.com/Hapfel1/er-save-manager/commit/e85e039e280c829b5bfacfd0e295866af0787f16))

- Trigger auto-backup on every game launch, not once per session `[backup]` ([2ee638d](https://github.com/Hapfel1/er-save-manager/commit/2ee638d81dde2d5b92010aa5b21622cd414550ed))

- Rename invasion regions to unlocked regions ([2e9ed01](https://github.com/Hapfel1/er-save-manager/commit/2e9ed010e0ba6a6a60fdb1b077623a1959485c5e))

- Detect and repair corrupted inventory item counters in character details ([fe5aa9c](https://github.com/Hapfel1/er-save-manager/commit/fe5aa9c48d238bd3bb32e8299cdceee876ef8d72))

- Add Event Flag mapping for maps and ashes of war ([6ceba63](https://github.com/Hapfel1/er-save-manager/commit/6ceba634e8d19c8843648d5284388ad88ab5a9eb))



### 🎨 User Interface

- Add Video Guide button for Ghost's video guide ([74b6f1e](https://github.com/Hapfel1/er-save-manager/commit/74b6f1ec39493a91525cd1843ee0c87b9cda825b))



### 📦 Dependencies

- Bump the github-actions group with 2 updates `[deps]` ([91cc328](https://github.com/Hapfel1/er-save-manager/commit/91cc328aa490335a822f45aba863c78ba70635ee))



### Data

- Migrate icon storage from zip to sqlite, fix nexus mods quarantine ([10d42eb](https://github.com/Hapfel1/er-save-manager/commit/10d42eb7e64d403d2e0dcba3d603a44cf629b5a2))



---