### PR TITLE
fix(build): exclude compiled extension packages from Windows zip

### DIFF
--- a/build-windows.py
+++ b/build-windows.py
@@ -73,6 +73,13 @@ build_exe_options = {
         "customtkinter",
         "customtkinterthemes",
         "PIL",
+        "pydantic_core",
+        "charset_normalizer",
+        "mmh3",
+        "multidict",
+        "propcache",
+        "pyroaring",
+        "yarl",
     ],
     "zip_include_packages": ["*"],
     # Exclude unused heavy dependencies found in environment


### PR DESCRIPTION
pydantic_core, charset_normalizer, mmh3, multidict, propcache, pyroaring and yarl ship native extension modules pulled in transitively via the supabase client. Extension modules cannot be imported from inside library.zip, which broke the character browser and preset browser on the Windows build (ModuleNotFoundError: pydantic_core._pydantic_core).