### PR TITLE
🚀 Release: ER Save Manager v1.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,25 @@
 > A comprehensive changelog for the Elden Ring Save Manager application.
 > All notable changes to this project are documented here.
 
+## 📦 Release 1.6.2
+**Released:** July 08, 2026
+
+
+### 🔧 Bug Fixes
+
+- Add missed Convergence Armor ([6b983d7](https://github.com/Hapfel1/er-save-manager/commit/6b983d7dca290dc7047f86956b116007efe1c065))
+
+- Fallback to storage on held-full during add/batch/loadout `[inventory]` ([a9b0c31](https://github.com/Hapfel1/er-save-manager/commit/a9b0c31ad4c293edea9b7bdaa9f8e8b4ccb1094d))
+
+
+
+### 📦 Dependencies
+
+- Bump the github-actions group with 2 updates `[deps]` ([335f1e8](https://github.com/Hapfel1/er-save-manager/commit/335f1e8838f724188fa37ae572b3e1b6320acdfb))
+
+
+
+---
 ## 📦 Release 1.6.1
 **Released:** July 03, 2026
 
@@ -1255,6 +1274,7 @@ implementation) ([77f66e6](https://github.com/Hapfel1/er-save-manager/commit/77f
 
 
 ---
+[1.6.2]: https://github.com/Hapfel1/er-save-manager/compare/v1.6.1..v1.6.2
 [1.6.1]: https://github.com/Hapfel1/er-save-manager/compare/v1.6.0..v1.6.1
 [1.6.0]: https://github.com/Hapfel1/er-save-manager/compare/v1.5.2..v1.6.0
 [1.5.2]: https://github.com/Hapfel1/er-save-manager/compare/v1.5.1..v1.5.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "er-save-manager"
-version = "1.6.1"
+version = "1.6.2"
 description = "Elden Ring Save File Editor, Backup Manager, and Corruption Fixer"
 readme = "README.md"
 license = "MIT"

--- a/resources/app.manifest
+++ b/resources/app.manifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
   <assemblyIdentity
-    version="1.6.1.0"
+    version="1.6.2.0"
     processorArchitecture="x86"
     name="ER.Save.Manager"
     type="win32"

--- a/resources/version.txt
+++ b/resources/version.txt
@@ -1,6 +1,6 @@
-version=1.6.1.0
-file_version=1.6.1.0
-product_version=1.6.1.0
+version=1.6.2.0
+file_version=1.6.2.0
+product_version=1.6.2.0
 company=ER Save Manager Contributors
 description=Elden Ring Save File Manager
 product=ER Save Manager

--- a/src/er_save_manager/__init__.py
+++ b/src/er_save_manager/__init__.py
@@ -26,4 +26,4 @@ __all__ = [
     "VersionChecker",
 ]
 
-__version__ = "1.6.1"
+__version__ = "1.6.2"

--- a/uv.lock
+++ b/uv.lock
@@ -325,7 +325,7 @@ wheels = [
 
 [[package]]
 name = "er-save-manager"
-version = "1.6.1"
+version = "1.6.2"
 source = { editable = "." }
 dependencies = [
     { name = "certifi" },


### PR DESCRIPTION
## 🚧 UNRELEASED

**This release is still under development.**
Changes in this PR will be included in the final release once merged.

---

## 📦 Release 1.6.2
**Released:** July 08, 2026


### 🔧 Bug Fixes

- Add missed Convergence Armor ([6b983d7](https://github.com/Hapfel1/er-save-manager/commit/6b983d7dca290dc7047f86956b116007efe1c065))

- Fallback to storage on held-full during add/batch/loadout `[inventory]` ([a9b0c31](https://github.com/Hapfel1/er-save-manager/commit/a9b0c31ad4c293edea9b7bdaa9f8e8b4ccb1094d))



### 📦 Dependencies

- Bump the github-actions group with 2 updates `[deps]` ([335f1e8](https://github.com/Hapfel1/er-save-manager/commit/335f1e8838f724188fa37ae572b3e1b6320acdfb))



---