### PR TITLE
🚀 Release: ER Save Manager v1.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,27 @@
 > A comprehensive changelog for the Elden Ring Save Manager application.
 > All notable changes to this project are documented here.
 
+## 📦 Release 1.6.3
+**Released:** July 20, 2026
+
+
+### 🔧 Bug Fixes
+
+- Add missing CHECKSUM_SIZE class constant `[character_ops]` ([bbdf7b5](https://github.com/Hapfel1/er-save-manager/commit/bbdf7b578e198066e67820fb2e1ff1b6f1a4cc6d))
+
+- Add Blessed Blue Dew Talisman Convergence variant to Convergence Talismans which reuses the Cerulean Seed Talisman's ID still with its old name in Params ([fd20f2c](https://github.com/Hapfel1/er-save-manager/commit/fd20f2c60436c4dfbb1029135262c86f60c3215f))
+
+
+
+### 📦 Dependencies
+
+- Bump the github-actions group with 2 updates `[deps]` ([f9929e3](https://github.com/Hapfel1/er-save-manager/commit/f9929e3c2a16445b68bef039acd58b84df3d4231))
+
+- Bump the github-actions group with 3 updates `[deps]` ([300306b](https://github.com/Hapfel1/er-save-manager/commit/300306b63927d9130352bcd1a1a2ffa21e34ed00))
+
+
+
+---
 ## 📦 Release 1.6.2
 **Released:** July 08, 2026
 
@@ -1274,6 +1295,7 @@ implementation) ([77f66e6](https://github.com/Hapfel1/er-save-manager/commit/77f
 
 
 ---
+[1.6.3]: https://github.com/Hapfel1/er-save-manager/compare/v1.6.2..v1.6.3
 [1.6.2]: https://github.com/Hapfel1/er-save-manager/compare/v1.6.1..v1.6.2
 [1.6.1]: https://github.com/Hapfel1/er-save-manager/compare/v1.6.0..v1.6.1
 [1.6.0]: https://github.com/Hapfel1/er-save-manager/compare/v1.5.2..v1.6.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "er-save-manager"
-version = "1.6.2"
+version = "1.6.3"
 description = "Elden Ring Save File Editor, Backup Manager, and Corruption Fixer"
 readme = "README.md"
 license = "MIT"

--- a/resources/app.manifest
+++ b/resources/app.manifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
   <assemblyIdentity
-    version="1.6.2.0"
+    version="1.6.3.0"
     processorArchitecture="x86"
     name="ER.Save.Manager"
     type="win32"

--- a/resources/version.txt
+++ b/resources/version.txt
@@ -1,6 +1,6 @@
-version=1.6.2.0
-file_version=1.6.2.0
-product_version=1.6.2.0
+version=1.6.3.0
+file_version=1.6.3.0
+product_version=1.6.3.0
 company=ER Save Manager Contributors
 description=Elden Ring Save File Manager
 product=ER Save Manager

--- a/src/er_save_manager/__init__.py
+++ b/src/er_save_manager/__init__.py
@@ -26,4 +26,4 @@ __all__ = [
     "VersionChecker",
 ]
 
-__version__ = "1.6.2"
+__version__ = "1.6.3"

--- a/uv.lock
+++ b/uv.lock
@@ -325,7 +325,7 @@ wheels = [
 
 [[package]]
 name = "er-save-manager"
-version = "1.6.2"
+version = "1.6.3"
 source = { editable = "." }
 dependencies = [
     { name = "certifi" },


### PR DESCRIPTION
## 🚧 UNRELEASED

**This release is still under development.**
Changes in this PR will be included in the final release once merged.

---

## 📦 Release 1.6.3
**Released:** July 20, 2026


### 🔧 Bug Fixes

- Add missing CHECKSUM_SIZE class constant `[character_ops]` ([bbdf7b5](https://github.com/Hapfel1/er-save-manager/commit/bbdf7b578e198066e67820fb2e1ff1b6f1a4cc6d))

- Add Blessed Blue Dew Talisman Convergence variant to Convergence Talismans which reuses the Cerulean Seed Talisman's ID still with its old name in Params ([fd20f2c](https://github.com/Hapfel1/er-save-manager/commit/fd20f2c60436c4dfbb1029135262c86f60c3215f))



### 📦 Dependencies

- Bump the github-actions group with 2 updates `[deps]` ([f9929e3](https://github.com/Hapfel1/er-save-manager/commit/f9929e3c2a16445b68bef039acd58b84df3d4231))

- Bump the github-actions group with 3 updates `[deps]` ([300306b](https://github.com/Hapfel1/er-save-manager/commit/300306b63927d9130352bcd1a1a2ffa21e34ed00))



---