### PR TITLE
🚀 Release: ER Save Manager v1.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,29 @@
 > A comprehensive changelog for the Elden Ring Save Manager application.
 > All notable changes to this project are documented here.
 
+## 📦 Release 1.7.2
+**Released:** July 27, 2026
+
+
+### 🔧 Bug Fixes
+
+- Fixed Typo and added flag 3001 which triggers NG on teleport to Roundtable Hold `[event_flags]` ([e5ba4ef](https://github.com/Hapfel1/er-save-manager/commit/e5ba4ef512a94499fd58916fed8d06b9669959f6))
+
+
+
+### 📖 Documentation
+
+- Replace MIT with source-available license `[license]` ([4b507ab](https://github.com/Hapfel1/er-save-manager/commit/4b507ab4818e8406395bd5505b7f0a518da96c58))
+
+
+
+### 📦 Dependencies
+
+- Bump the github-actions group with 3 updates `[deps]` ([14e0301](https://github.com/Hapfel1/er-save-manager/commit/14e0301acbc72bf04ebc18174ae5477ecbd1dc22))
+
+
+
+---
 ## 📦 Release 1.7.1
 **Released:** July 22, 2026
 
@@ -1360,6 +1383,7 @@ implementation) ([77f66e6](https://github.com/Hapfel1/er-save-manager/commit/77f
 
 
 ---
+[1.7.2]: https://github.com/Hapfel1/er-save-manager/compare/v1.7.1..v1.7.2
 [1.7.1]: https://github.com/Hapfel1/er-save-manager/compare/v1.7.0..v1.7.1
 [1.7.0]: https://github.com/Hapfel1/er-save-manager/compare/v1.6.2..v1.7.0
 [1.6.2]: https://github.com/Hapfel1/er-save-manager/compare/v1.6.1..v1.6.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "er-save-manager"
-version = "1.7.1"
+version = "1.7.2"
 description = "Elden Ring Save File Editor, Backup Manager, and Corruption Fixer"
 readme = "README.md"
 license = "MIT"

--- a/resources/app.manifest
+++ b/resources/app.manifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
   <assemblyIdentity
-    version="1.7.1.0"
+    version="1.7.2.0"
     processorArchitecture="x86"
     name="ER.Save.Manager"
     type="win32"

--- a/resources/version.txt
+++ b/resources/version.txt
@@ -1,6 +1,6 @@
-version=1.7.1.0
-file_version=1.7.1.0
-product_version=1.7.1.0
+version=1.7.2.0
+file_version=1.7.2.0
+product_version=1.7.2.0
 company=ER Save Manager Contributors
 description=Elden Ring Save File Manager
 product=ER Save Manager

--- a/src/er_save_manager/__init__.py
+++ b/src/er_save_manager/__init__.py
@@ -26,4 +26,4 @@ __all__ = [
     "VersionChecker",
 ]
 
-__version__ = "1.7.1"
+__version__ = "1.7.2"

--- a/uv.lock
+++ b/uv.lock
@@ -325,7 +325,7 @@ wheels = [
 
 [[package]]
 name = "er-save-manager"
-version = "1.7.1"
+version = "1.7.2"
 source = { editable = "." }
 dependencies = [
     { name = "certifi" },


### PR DESCRIPTION
## 🚧 UNRELEASED

**This release is still under development.**
Changes in this PR will be included in the final release once merged.

---

## 📦 Release 1.7.2
**Released:** July 27, 2026


### 🔧 Bug Fixes

- Fixed Typo and added flag 3001 which triggers NG on teleport to Roundtable Hold `[event_flags]` ([e5ba4ef](https://github.com/Hapfel1/er-save-manager/commit/e5ba4ef512a94499fd58916fed8d06b9669959f6))



### 📖 Documentation

- Replace MIT with source-available license `[license]` ([4b507ab](https://github.com/Hapfel1/er-save-manager/commit/4b507ab4818e8406395bd5505b7f0a518da96c58))



### 📦 Dependencies

- Bump the github-actions group with 3 updates `[deps]` ([14e0301](https://github.com/Hapfel1/er-save-manager/commit/14e0301acbc72bf04ebc18174ae5477ecbd1dc22))



---