### PR TITLE
fix(platform): kill correct process when force-terminating non-ER games

### DIFF
--- a/src/er_save_manager/platform/utils.py
+++ b/src/er_save_manager/platform/utils.py
@@ -66,19 +66,19 @@ class PlatformUtils:
         return False
 
     @staticmethod
-    def kill_game_process() -> bool:
-        """Force kill Elden Ring process."""
+    def kill_game_process(process_name: str = "eldenring.exe") -> bool:
+        """Force kill the given game process."""
         try:
             if PlatformUtils.is_windows():
                 subprocess.run(
-                    ["taskkill", "/F", "/IM", "eldenring.exe"],
+                    ["taskkill", "/F", "/IM", process_name],
                     creationflags=subprocess.CREATE_NO_WINDOW,
                     check=True,
                 )
                 return True
             elif PlatformUtils.is_linux():
                 subprocess.run(
-                    ["pkill", "-9", "-f", "eldenring.exe"],
+                    ["pkill", "-9", "-f", process_name],
                     check=True,
                 )
                 return True

--- a/src/er_save_manager/ui/gui.py
+++ b/src/er_save_manager/ui/gui.py
@@ -301,7 +301,7 @@ class SaveManagerGUI:
         if not result:
             return False
 
-        if not PlatformUtils.kill_game_process():
+        if not PlatformUtils.kill_game_process(process_name):
             CTkMessageBox.showerror(
                 "Error",
                 f"Failed to terminate {game_name} process.\n\n"


### PR DESCRIPTION
kill_game_process() was hardcoded to eldenring.exe, so the force-kill option in the game-running dialog always targeted Elden Ring even when triggered for DS3, Sekiro, or other profiles. Added a process_name parameter and pass the resolved profile process name from gui.py.