### PR TITLE
🚀 Release: ER Save Manager v1.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,31 @@
 > A comprehensive changelog for the Elden Ring Save Manager application.
 > All notable changes to this project are documented here.
 
+## 📦 Release 1.8.1
+**Released:** August 10, 2026
+
+
+### 🔧 Bug Fixes
+
+- Use correct empty-slot sentinel when writing gesture array `[gestures]` ([1c401aa](https://github.com/Hapfel1/er-save-manager/commit/1c401aa4216639ba8b93164c0c551e159601ca19))
+
+- Added missed item, Lantern `[item-db]` ([d257897](https://github.com/Hapfel1/er-save-manager/commit/d2578973b849c0702305c0e1e5462224700e39ce))
+
+- Add missed items for Convergence `[item_db]` ([bbcde60](https://github.com/Hapfel1/er-save-manager/commit/bbcde601388f8a0f3a000f46d663fa5ce63f075e))
+
+- Scope gaitem lookup to target inventory location `[inventory]` ([ced4e8c](https://github.com/Hapfel1/er-save-manager/commit/ced4e8c0f5c50f9d7e0ed7edb32617647a86dcbe))
+
+
+
+### 📦 Dependencies
+
+- Bump the github-actions group with 2 updates `[deps]` ([4f9da42](https://github.com/Hapfel1/er-save-manager/commit/4f9da4286be6a47ddc61e51b1460445b40b8969b))
+
+- Bump taiki-e/install-action in the github-actions group `[deps]` ([2bcdb07](https://github.com/Hapfel1/er-save-manager/commit/2bcdb07330358b639fc958299c71a0557401cb2e))
+
+
+
+---
 ## 📦 Release 1.8.0
 **Released:** July 30, 2026
 
@@ -1435,6 +1460,7 @@ implementation) ([77f66e6](https://github.com/Hapfel1/er-save-manager/commit/77f
 
 
 ---
+[1.8.1]: https://github.com/Hapfel1/er-save-manager/compare/v1.8.0..v1.8.1
 [1.8.0]: https://github.com/Hapfel1/er-save-manager/compare/v1.7.1..v1.8.0
 [1.7.1]: https://github.com/Hapfel1/er-save-manager/compare/v1.7.0..v1.7.1
 [1.7.0]: https://github.com/Hapfel1/er-save-manager/compare/v1.6.2..v1.7.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "er-save-manager"
-version = "1.8.0"
+version = "1.8.1"
 description = "Elden Ring Save File Editor, Backup Manager, and Corruption Fixer"
 readme = "README.md"
 license = "MIT"

--- a/resources/app.manifest
+++ b/resources/app.manifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
   <assemblyIdentity
-    version="1.8.0.0"
+    version="1.8.1.0"
     processorArchitecture="x86"
     name="ER.Save.Manager"
     type="win32"

--- a/resources/version.txt
+++ b/resources/version.txt
@@ -1,6 +1,6 @@
-version=1.8.0.0
-file_version=1.8.0.0
-product_version=1.8.0.0
+version=1.8.1.0
+file_version=1.8.1.0
+product_version=1.8.1.0
 company=ER Save Manager Contributors
 description=Elden Ring Save File Manager
 product=ER Save Manager

--- a/src/er_save_manager/__init__.py
+++ b/src/er_save_manager/__init__.py
@@ -26,4 +26,4 @@ __all__ = [
     "VersionChecker",
 ]
 
-__version__ = "1.8.0"
+__version__ = "1.8.1"

--- a/uv.lock
+++ b/uv.lock
@@ -325,7 +325,7 @@ wheels = [
 
 [[package]]
 name = "er-save-manager"
-version = "1.8.0"
+version = "1.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "certifi" },


### PR DESCRIPTION
## 🚧 UNRELEASED

**This release is still under development.**
Changes in this PR will be included in the final release once merged.

---

## 📦 Release 1.8.1
**Released:** August 10, 2026


### 🔧 Bug Fixes

- Use correct empty-slot sentinel when writing gesture array `[gestures]` ([1c401aa](https://github.com/Hapfel1/er-save-manager/commit/1c401aa4216639ba8b93164c0c551e159601ca19))

- Added missed item, Lantern `[item-db]` ([d257897](https://github.com/Hapfel1/er-save-manager/commit/d2578973b849c0702305c0e1e5462224700e39ce))

- Add missed items for Convergence `[item_db]` ([bbcde60](https://github.com/Hapfel1/er-save-manager/commit/bbcde601388f8a0f3a000f46d663fa5ce63f075e))

- Scope gaitem lookup to target inventory location `[inventory]` ([ced4e8c](https://github.com/Hapfel1/er-save-manager/commit/ced4e8c0f5c50f9d7e0ed7edb32617647a86dcbe))



### 📦 Dependencies

- Bump the github-actions group with 2 updates `[deps]` ([4f9da42](https://github.com/Hapfel1/er-save-manager/commit/4f9da4286be6a47ddc61e51b1460445b40b8969b))

- Bump taiki-e/install-action in the github-actions group `[deps]` ([2bcdb07](https://github.com/Hapfel1/er-save-manager/commit/2bcdb07330358b639fc958299c71a0557401cb2e))



---