### PR TITLE
fix(inventory): allow visual inventory and icon browser open together

### DIFF
--- a/src/er_save_manager/ui/editors/inventory_editor.py
+++ b/src/er_save_manager/ui/editors/inventory_editor.py
@@ -720,6 +720,8 @@ class InventoryEditor:
         self._forced_selection: tuple | None = None
         self._affinity_icon_lbl: ctk.CTkLabel | None = None
         self._aow_icon_lbl: ctk.CTkLabel | None = None
+        self._visual_inventory_win = None
+        self._icon_browser_win = None
 
         self._search_var: ctk.StringVar | None = None
         self._search_cat_var: ctk.StringVar | None = None
@@ -1400,9 +1402,14 @@ class InventoryEditor:
         self._browse_btn.configure(state="normal")
 
     def _open_visual_inventory(self) -> None:
+        win = self._visual_inventory_win
+        if win is not None and win.winfo_exists():
+            win.raise_window()
+            return
+
         from er_save_manager.ui.visual_inventory import VisualInventoryBrowser
 
-        VisualInventoryBrowser(self.parent, self)
+        self._visual_inventory_win = VisualInventoryBrowser(self.parent, self)
 
     def _on_affinity_combo_changed(self, value: str) -> None:
         self._update_affinity_icon(value)
@@ -1447,6 +1454,11 @@ class InventoryEditor:
             self._update_browse_state()
 
     def _open_icon_browser(self):
+        win = self._icon_browser_win
+        if win is not None and win.winfo_exists():
+            win.raise_window()
+            return
+
         cat = self._search_cat_var.get() if hasattr(self, "_search_cat_var") else "All"
         cats = self._visible_categories()
         if cat == "All":
@@ -1457,7 +1469,7 @@ class InventoryEditor:
         dev_icon_export = (
             settings.get("icon_export_enabled", False) if settings else False
         )
-        IconBrowser(
+        self._icon_browser_win = IconBrowser(
             self.parent, self, initial_category=cat, dev_icon_export=dev_icon_export
         )
 

--- a/src/er_save_manager/ui/icon_browser.py
+++ b/src/er_save_manager/ui/icon_browser.py
@@ -127,7 +127,8 @@ class IconBrowser(ctk.CTkToplevel):
         self.update_idletasks()
         _center_over(self, parent, w, 800, top=True)
         self.attributes("-alpha", 1)
-        self.grab_set()
+        # Non-modal by design: the visual inventory may be open at the same time
+        self.raise_window()
 
         self._build_ui()
 
@@ -139,6 +140,14 @@ class IconBrowser(ctk.CTkToplevel):
 
         self._scroll.bind("<Configure>", self._on_scroll_resize)
         self.after(120, self._reflow)
+
+    def raise_window(self) -> None:
+        """Bring the window forward. Called on open and when reopened from the editor."""
+        if not self.winfo_exists():
+            return
+        self.deiconify()
+        self.lift()
+        self.focus_force()
 
     # ---- UI ------------------------------------------------------------------
 

--- a/src/er_save_manager/ui/visual_inventory.py
+++ b/src/er_save_manager/ui/visual_inventory.py
@@ -189,13 +189,22 @@ class VisualInventoryBrowser(ctk.CTkToplevel):
         self.minsize(500, 400)
         self.resizable(True, True)
         self.transient(parent)
-        self.after(100, self.grab_set)
 
         self._build_ui()
         self._rebuild()
         _center_over(self, parent, 760, 680, top=True)
+        # Non-modal by design: the icon browser may be open at the same time
+        self.after(100, self.raise_window)
         self._editor._inventory_change_listeners.append(self._on_editor_changed)
         self.protocol("WM_DELETE_WINDOW", self._on_close)
+
+    def raise_window(self) -> None:
+        """Bring the window forward. Called on open and when reopened from the editor."""
+        if not self.winfo_exists():
+            return
+        self.deiconify()
+        self.lift()
+        self.focus_force()
 
     # ---- UI ------------------------------------------------------------------
 


### PR DESCRIPTION
Both popups called grab_set(), so the last one opened held an application grab and blocked input to the other. Replace the grab with raise_window() and track a single instance of each on the editor so reopening raises the existing window instead of spawning a duplicate.

Nested dialogs keep their own grab and stay modal.