### PR TITLE
🚀 Release: ER Save Manager v1.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@
 > A comprehensive changelog for the Elden Ring Save Manager application.
 > All notable changes to this project are documented here.
 
+## 📦 Release 1.9.2
+**Released:** September 01, 2026
+
+
+### 📦 Dependencies
+
+- Bump taiki-e/install-action in the github-actions group `[deps]` ([9a110ea](https://github.com/Hapfel1/er-save-manager/commit/9a110eae9f6ebd5c6a00a3d2a5cb0a11ca52bcb8))
+
+- Bump taiki-e/install-action in the github-actions group `[deps]` ([dd90ef2](https://github.com/Hapfel1/er-save-manager/commit/dd90ef22a50394d91a79e64da572b1f63073e68e))
+
+
+
+---
 ## 📦 Release 1.9.1
 **Released:** August 17, 2026
 
@@ -1505,6 +1518,7 @@ implementation) ([77f66e6](https://github.com/Hapfel1/er-save-manager/commit/77f
 
 
 ---
+[1.9.2]: https://github.com/Hapfel1/er-save-manager/compare/v1.9.1..v1.9.2
 [1.9.1]: https://github.com/Hapfel1/er-save-manager/compare/v1.9.0..v1.9.1
 [1.9.0]: https://github.com/Hapfel1/er-save-manager/compare/v1.8.0..v1.9.0
 [1.8.0]: https://github.com/Hapfel1/er-save-manager/compare/v1.7.1..v1.8.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "er-save-manager"
-version = "1.9.1"
+version = "1.9.2"
 description = "Elden Ring Save File Editor, Backup Manager, and Corruption Fixer"
 readme = "README.md"
 license = "MIT"

--- a/resources/app.manifest
+++ b/resources/app.manifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
   <assemblyIdentity
-    version="1.9.1.0"
+    version="1.9.2.0"
     processorArchitecture="x86"
     name="ER.Save.Manager"
     type="win32"

--- a/resources/version.txt
+++ b/resources/version.txt
@@ -1,6 +1,6 @@
-version=1.9.1.0
-file_version=1.9.1.0
-product_version=1.9.1.0
+version=1.9.2.0
+file_version=1.9.2.0
+product_version=1.9.2.0
 company=ER Save Manager Contributors
 description=Elden Ring Save File Manager
 product=ER Save Manager

--- a/src/er_save_manager/__init__.py
+++ b/src/er_save_manager/__init__.py
@@ -26,4 +26,4 @@ __all__ = [
     "VersionChecker",
 ]
 
-__version__ = "1.9.1"
+__version__ = "1.9.2"

--- a/uv.lock
+++ b/uv.lock
@@ -319,7 +319,7 @@ wheels = [
 
 [[package]]
 name = "er-save-manager"
-version = "1.9.1"
+version = "1.9.2"
 source = { editable = "." }
 dependencies = [
     { name = "certifi" },


### PR DESCRIPTION
## 🚧 UNRELEASED

**This release is still under development.**
Changes in this PR will be included in the final release once merged.

---

## 📦 Release 1.9.2
**Released:** September 01, 2026


### 📦 Dependencies

- Bump taiki-e/install-action in the github-actions group `[deps]` ([9a110ea](https://github.com/Hapfel1/er-save-manager/commit/9a110eae9f6ebd5c6a00a3d2a5cb0a11ca52bcb8))

- Bump taiki-e/install-action in the github-actions group `[deps]` ([dd90ef2](https://github.com/Hapfel1/er-save-manager/commit/dd90ef22a50394d91a79e64da572b1f63073e68e))



---