### PR TITLE
fix(gui): prevent EAC warning from silently cancelling save load

### DIFF
--- a/src/er_save_manager/ui/gui.py
+++ b/src/er_save_manager/ui/gui.py
@@ -2016,11 +2016,15 @@ class SaveManagerGUI:
         ):
             # Create custom dialog with "Don't show again" option
             warning_dialog = tk.Toplevel(self.root)
-            warning_dialog.title("⚠️ Warning - Vanilla Save File Detected")
+            warning_dialog.title("Warning - Vanilla Save File Detected")
             warning_dialog.geometry("520x600")
             warning_dialog.transient(self.root)
             warning_dialog.update_idletasks()
             warning_dialog.grab_set()
+
+            from er_save_manager.ui.utils import force_render_dialog
+
+            force_render_dialog(warning_dialog)
 
             # Warning message
             msg_frame = ttk.Frame(warning_dialog, padding=20)
@@ -2085,11 +2089,18 @@ class SaveManagerGUI:
                 side=tk.LEFT, padx=5
             )
 
+            # Route the title bar close button through the same explicit
+            # cancel path so dismissing the window is never silently
+            # different from clicking "No, Cancel".
+            warning_dialog.protocol("WM_DELETE_WINDOW", on_no)
+
             # Wait for dialog to close
             self.root.wait_window(warning_dialog)
 
             if not result["continue"]:
-                self.status_var.set("Load cancelled by user")
+                self.status_var.set(
+                    "Load cancelled - click 'Yes, Continue' in the warning to load a vanilla save"
+                )
                 return
 
         # Route non-ER games to their own loaders so the Load button works too


### PR DESCRIPTION
Closing the vanilla save warning via the title bar destroyed the dialog without setting result["continue"], which is indistinguishable from an explicit "No, Cancel" click but gave no feedback on why the load stopped. Users closing the dialog out of habit had no way to tell the load was cancelled rather than broken.

Bind WM_DELETE_WINDOW to the same on_no handler used by the Cancel button so closing the dialog is always an explicit, acknowledged cancel. Call force_render_dialog so the warning reliably gets focus on Linux instead of appearing unresponsive. Update the status message to tell the user what to do instead of just stating it was cancelled.

Fixes #262