### PR TITLE
🚀 Release: ER Save Manager v1.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@
 > A comprehensive changelog for the Elden Ring Save Manager application.
 > All notable changes to this project are documented here.
 
+## 📦 Release 1.10.1
+**Released:** September 02, 2026
+
+
+### 🔧 Bug Fixes
+
+- Add save/game version mismatch fix `[ui]` ([f2c8e4c](https://github.com/Hapfel1/er-save-manager/commit/f2c8e4c9d6205d5ebd2d1f0d5f8e9a7ec75c59b0))
+
+
+
+### 📦 Dependencies
+
+- Bump urllib3 from 2.6.3 to 2.7.0 `[deps]` ([7d8069a](https://github.com/Hapfel1/er-save-manager/commit/7d8069a21935446dbb971c5bfda2f48d9844274a))
+
+
+
+---
 ## 📦 Release 1.10.0
 **Released:** September 01, 2026
 
@@ -1532,6 +1549,7 @@ implementation) ([77f66e6](https://github.com/Hapfel1/er-save-manager/commit/77f
 
 
 ---
+[1.10.1]: https://github.com/Hapfel1/er-save-manager/compare/v1.10.0..v1.10.1
 [1.10.0]: https://github.com/Hapfel1/er-save-manager/compare/v1.9.1..v1.10.0
 [1.9.1]: https://github.com/Hapfel1/er-save-manager/compare/v1.9.0..v1.9.1
 [1.9.0]: https://github.com/Hapfel1/er-save-manager/compare/v1.8.0..v1.9.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "er-save-manager"
-version = "1.10.0"
+version = "1.10.1"
 description = "Elden Ring Save File Editor, Backup Manager, and Corruption Fixer"
 readme = "README.md"
 license = "MIT"

--- a/resources/app.manifest
+++ b/resources/app.manifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
   <assemblyIdentity
-    version="1.10.0.0"
+    version="1.10.1.0"
     processorArchitecture="x86"
     name="ER.Save.Manager"
     type="win32"

--- a/resources/version.txt
+++ b/resources/version.txt
@@ -1,6 +1,6 @@
-version=1.10.0.0
-file_version=1.10.0.0
-product_version=1.10.0.0
+version=1.10.1.0
+file_version=1.10.1.0
+product_version=1.10.1.0
 company=ER Save Manager Contributors
 description=Elden Ring Save File Manager
 product=ER Save Manager

--- a/src/er_save_manager/__init__.py
+++ b/src/er_save_manager/__init__.py
@@ -26,4 +26,4 @@ __all__ = [
     "VersionChecker",
 ]
 
-__version__ = "1.10.0"
+__version__ = "1.10.1"

--- a/uv.lock
+++ b/uv.lock
@@ -319,7 +319,7 @@ wheels = [
 
 [[package]]
 name = "er-save-manager"
-version = "1.10.0"
+version = "1.10.1"
 source = { editable = "." }
 dependencies = [
     { name = "certifi" },


### PR DESCRIPTION
## 🚧 UNRELEASED

**This release is still under development.**
Changes in this PR will be included in the final release once merged.

---

## 📦 Release 1.10.1
**Released:** September 02, 2026


### 🔧 Bug Fixes

- Add save/game version mismatch fix `[ui]` ([f2c8e4c](https://github.com/Hapfel1/er-save-manager/commit/f2c8e4c9d6205d5ebd2d1f0d5f8e9a7ec75c59b0))



### 📦 Dependencies

- Bump urllib3 from 2.6.3 to 2.7.0 `[deps]` ([7d8069a](https://github.com/Hapfel1/er-save-manager/commit/7d8069a21935446dbb971c5bfda2f48d9844274a))



---