### PR TITLE
fix(ui): add save/game version mismatch fix

### DIFF
--- a/src/er_save_manager/fixes/version_mismatch.py
+++ b/src/er_save_manager/fixes/version_mismatch.py
@@ -1,0 +1,156 @@
+"""
+Save/game version mismatch fix.
+
+Elden Ring stamps a version number in three places: the global
+USER_DATA_10.version, and per-slot version + BaseVersion
+(base_version_copy, base_version, is_latest_version). Loading a
+save on a newer game build bumps these values immediately, even
+without full gameplay on that slot, so touching the character
+select screen alone is enough to raise the global stamp. An older
+executable then refuses to load the file with a version-incompatible
+message.
+
+This does not fit the per-slot BaseFix interface (detect/apply take
+a slot_index) since the global stamp and every active slot need to
+move together. Kept as a standalone module instead.
+"""
+
+from __future__ import annotations
+
+import struct
+from dataclasses import dataclass, field
+from io import BytesIO
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from er_save_manager.parser import Save
+
+CHECKSUM_SIZE = 0x10
+BASE_VERSION_SIZE = 0x10
+
+
+@dataclass
+class SlotVersionInfo:
+    """Version stamps found in one active character slot."""
+
+    slot_index: int
+    version: int
+    base_version: int
+    is_latest_version: int
+
+
+@dataclass
+class VersionInfo:
+    """Version stamps found across the whole save file."""
+
+    user_data_10_version: int
+    slots: list[SlotVersionInfo] = field(default_factory=list)
+
+    @property
+    def highest_version(self) -> int:
+        """Highest version stamp found anywhere in the file."""
+        values = [self.user_data_10_version] + [s.version for s in self.slots]
+        return max(values) if values else 0
+
+    @property
+    def has_mismatch(self) -> bool:
+        """True if any two version stamps in the file disagree."""
+        values = {self.user_data_10_version}
+        for s in self.slots:
+            values.add(s.version)
+            values.add(s.base_version)
+        return len(values) > 1
+
+
+@dataclass
+class VersionFixResult:
+    """Result of applying the version downgrade fix."""
+
+    applied: bool = False
+    description: str = ""
+    details: list[str] = field(default_factory=list)
+
+
+def get_version_info(save: Save) -> VersionInfo:
+    """Read current version stamps from a save without modifying it."""
+    info = VersionInfo(user_data_10_version=save.user_data_10_parsed.version)
+    for i, slot in enumerate(save.character_slots):
+        if slot.is_empty():
+            continue
+        info.slots.append(
+            SlotVersionInfo(
+                slot_index=i,
+                version=slot.version,
+                base_version=slot.base_version.base_version,
+                is_latest_version=slot.base_version.is_latest_version,
+            )
+        )
+    return info
+
+
+def apply_version_downgrade(save: Save, target_version: int) -> VersionFixResult:
+    """
+    Rewrite the global and every active per-slot version stamp to
+    target_version, then recalculate checksums.
+
+    Does not write to disk - caller is responsible for save.to_file().
+
+    Args:
+        save: The save file (will be modified in place)
+        target_version: Version number to stamp everywhere
+
+    Returns:
+        VersionFixResult describing what changed
+    """
+    if target_version <= 0:
+        return VersionFixResult(
+            applied=False, description="Target version must be a positive integer"
+        )
+
+    details = []
+
+    # Global USER_DATA_10.version. PS saves have no per-section checksum.
+    ud10_offset = save._user_data_10_offset
+    version_offset = ud10_offset if save.is_ps else ud10_offset + CHECKSUM_SIZE
+    old_global = save.user_data_10_parsed.version
+    save._raw_data[version_offset : version_offset + 4] = struct.pack(
+        "<I", target_version
+    )
+    save.user_data_10_parsed.version = target_version
+    details.append(f"Global save version: {old_global} -> {target_version}")
+
+    # Per-slot version + BaseVersion for every active slot.
+    for i, slot in enumerate(save.character_slots):
+        if slot.is_empty():
+            continue
+
+        old_slot_version = slot.version
+        save._raw_data[slot.data_start : slot.data_start + 4] = struct.pack(
+            "<I", target_version
+        )
+        slot.version = target_version
+
+        old_base_version = slot.base_version.base_version
+        slot.base_version.base_version_copy = target_version
+        slot.base_version.base_version = target_version
+        slot.base_version.is_latest_version = 1
+
+        base_version_offset = slot.steamid_offset - BASE_VERSION_SIZE
+        buf = BytesIO()
+        slot.base_version.write(buf)
+        save._raw_data[
+            base_version_offset : base_version_offset + BASE_VERSION_SIZE
+        ] = buf.getvalue()
+
+        details.append(
+            f"Slot {i + 1}: version {old_slot_version} -> {target_version}, "
+            f"base_version {old_base_version} -> {target_version}"
+        )
+
+    save.recalculate_checksums()
+
+    return VersionFixResult(
+        applied=True,
+        description=f"All version stamps set to {target_version}",
+        details=details,
+    )

--- a/src/er_save_manager/ui/tabs/save_inspector_tab.py
+++ b/src/er_save_manager/ui/tabs/save_inspector_tab.py
@@ -9,6 +9,7 @@ import customtkinter as ctk
 
 from er_save_manager.ui.messagebox import CTkMessageBox
 from er_save_manager.ui.utils import bind_mousewheel
+from er_save_manager.ui.version_mismatch_dialog import VersionMismatchDialog
 
 
 class SaveInspectorTab:
@@ -66,6 +67,14 @@ class SaveInspectorTab:
             command=self.show_character_details,
             width=180,
         ).pack(side="right")
+
+        ctk.CTkButton(
+            header,
+            text="Mismatched Game/Save Version?",
+            command=self.show_version_mismatch_dialog,
+            fg_color=("gray70", "gray35"),
+            width=220,
+        ).pack(side="right", padx=(0, 8))
 
         # Instructions
         instructions_frame = ctk.CTkFrame(char_frame, fg_color="transparent")
@@ -221,3 +230,19 @@ class SaveInspectorTab:
 
         if self.show_details:
             self.show_details(self.selected_slot)
+
+    def show_version_mismatch_dialog(self):
+        """Open the save/game version mismatch fix dialog."""
+        save_file = self.get_save_file()
+        if not save_file:
+            CTkMessageBox.showwarning(
+                "No Save Loaded", "Please load a save file first!", parent=self.parent
+            )
+            return
+
+        VersionMismatchDialog(
+            self.parent.winfo_toplevel(),
+            save_file,
+            self.get_save_path(),
+            self.reload_save,
+        )

--- a/src/er_save_manager/ui/version_mismatch_dialog.py
+++ b/src/er_save_manager/ui/version_mismatch_dialog.py
@@ -39,7 +39,7 @@ class VersionMismatchDialog(ctk.CTkToplevel):
         self.protocol("WM_DELETE_WINDOW", self.destroy)
         self._build_ui()
 
-        width, height = 520, 420
+        width, height = 520, 520
         self.geometry(f"{width}x{height}")
         self.update_idletasks()
         px = parent.winfo_rootx() + (parent.winfo_width() - width) // 2

--- a/src/er_save_manager/ui/version_mismatch_dialog.py
+++ b/src/er_save_manager/ui/version_mismatch_dialog.py
@@ -1,0 +1,193 @@
+"""Dialog for fixing a save/game version mismatch."""
+
+from pathlib import Path
+
+import customtkinter as ctk
+
+from er_save_manager.fixes.version_mismatch import (
+    apply_version_downgrade,
+    get_version_info,
+)
+from er_save_manager.ui.messagebox import CTkMessageBox
+
+RECOMMENDED_VERSION = 252
+RECOMMENDED_GAME_LABEL = "1.16.2"
+MIN_VALID_VERSION = 1
+MAX_VALID_VERSION = 9999
+
+
+class VersionMismatchDialog(ctk.CTkToplevel):
+    """
+    Explains the save/game version mismatch issue and lets the user
+    rewrite every version stamp in the save to a target value so an
+    older game build will load it again.
+    """
+
+    def __init__(self, parent, save_file, save_path, reload_callback):
+        super().__init__(parent)
+        self.title("Mismatched Game/Save Version")
+        self.resizable(False, False)
+        self.transient(parent)
+
+        self._save_file = save_file
+        self._save_path = save_path
+        self._reload_callback = reload_callback
+
+        self._target_var = ctk.StringVar(value=str(RECOMMENDED_VERSION))
+        self._status_var = ctk.StringVar(value="")
+
+        self.protocol("WM_DELETE_WINDOW", self.destroy)
+        self._build_ui()
+
+        width, height = 520, 420
+        self.geometry(f"{width}x{height}")
+        self.update_idletasks()
+        px = parent.winfo_rootx() + (parent.winfo_width() - width) // 2
+        py = parent.winfo_rooty() + (parent.winfo_height() - height) // 2
+        self.geometry(f"{width}x{height}+{px}+{py}")
+
+        from er_save_manager.ui.utils import force_render_dialog
+
+        force_render_dialog(self)
+        self.grab_set()
+
+    def _build_ui(self):
+        main = ctk.CTkFrame(self, fg_color="transparent")
+        main.pack(fill="both", expand=True, padx=20, pady=16)
+
+        ctk.CTkLabel(
+            main,
+            text="Mismatched Game/Save Version",
+            font=("Segoe UI", 13, "bold"),
+        ).pack(anchor="w")
+
+        ctk.CTkLabel(
+            main,
+            text=(
+                "Elden Ring stamps a version number into the save the moment "
+                "it is opened by a newer game build, even without loading a "
+                "character into gameplay. If the game is later downpatched to "
+                "an older build, that save is refused with a version-"
+                "incompatible message.\n\n"
+                "This rewrites the version stamps back down so the save "
+                "opens on an older build again. A backup is made first."
+            ),
+            font=("Segoe UI", 11),
+            justify="left",
+            wraplength=470,
+        ).pack(anchor="w", pady=(8, 12))
+
+        detected_frame = ctk.CTkFrame(main, fg_color=("gray90", "gray20"))
+        detected_frame.pack(fill="x", pady=(0, 12))
+
+        detected_text = self._describe_detected_versions()
+        ctk.CTkLabel(
+            detected_frame,
+            text=detected_text,
+            font=("Courier", 11),
+            justify="left",
+            anchor="w",
+        ).pack(fill="x", padx=10, pady=8)
+
+        target_row = ctk.CTkFrame(main, fg_color="transparent")
+        target_row.pack(fill="x", pady=(0, 4))
+
+        ctk.CTkLabel(target_row, text="Target version:").pack(side="left", padx=(0, 8))
+        ctk.CTkEntry(target_row, textvariable=self._target_var, width=80).pack(
+            side="left", padx=(0, 8)
+        )
+        ctk.CTkButton(
+            target_row,
+            text=f"Use Recommended ({RECOMMENDED_VERSION} / game {RECOMMENDED_GAME_LABEL})",
+            command=self._use_recommended,
+            width=240,
+        ).pack(side="left")
+
+        ctk.CTkLabel(
+            main,
+            textvariable=self._status_var,
+            font=("Segoe UI", 11),
+            text_color=("#b00020", "#ff6b6b"),
+            justify="left",
+            wraplength=470,
+        ).pack(anchor="w", pady=(4, 8))
+
+        btn_row = ctk.CTkFrame(main, fg_color="transparent")
+        btn_row.pack(fill="x", side="bottom")
+        ctk.CTkButton(
+            btn_row,
+            text="Cancel",
+            command=self.destroy,
+            fg_color=("gray70", "gray35"),
+            width=100,
+        ).pack(side="right")
+        ctk.CTkButton(
+            btn_row,
+            text="Apply Fix",
+            command=self._on_apply,
+            width=140,
+        ).pack(side="right", padx=(0, 8))
+
+    def _describe_detected_versions(self) -> str:
+        info = get_version_info(self._save_file)
+        lines = [f"Global save version: {info.user_data_10_version}"]
+        for s in info.slots:
+            lines.append(f"Slot {s.slot_index + 1:2d}: version={s.version}")
+        return "\n".join(lines)
+
+    def _use_recommended(self):
+        self._target_var.set(str(RECOMMENDED_VERSION))
+
+    def _validate_target(self) -> int | None:
+        raw = self._target_var.get().strip()
+        if not raw.isdigit():
+            self._status_var.set("Target version must be a whole number.")
+            return None
+        value = int(raw)
+        if not (MIN_VALID_VERSION <= value <= MAX_VALID_VERSION):
+            self._status_var.set(
+                f"Target version must be between {MIN_VALID_VERSION} and {MAX_VALID_VERSION}."
+            )
+            return None
+        self._status_var.set("")
+        return value
+
+    def _on_apply(self):
+        target_version = self._validate_target()
+        if target_version is None:
+            return
+
+        try:
+            if self._save_path:
+                from er_save_manager.backup.manager import BackupManager
+
+                manager = BackupManager(Path(self._save_path))
+                manager.create_backup(
+                    description="before_version_mismatch_fix",
+                    operation="version_mismatch_fix",
+                    save=self._save_file,
+                )
+
+            result = apply_version_downgrade(self._save_file, target_version)
+
+            if not result.applied:
+                self._status_var.set(result.description)
+                return
+
+            if self._save_path:
+                self._save_file.to_file(Path(self._save_path))
+
+            if self._reload_callback:
+                self._reload_callback()
+
+            parent = self.master
+            self.destroy()
+            CTkMessageBox.showinfo(
+                "Version Fixed",
+                f"{result.description}\n\nThe save file has been updated.",
+                parent=parent,
+            )
+        except Exception as e:
+            CTkMessageBox.showerror(
+                "Error", f"Failed to apply version fix:\n{e}", parent=self
+            )


### PR DESCRIPTION
Elden Ring stamps a version number in three places: the global USER_DATA_10.version, and per-slot version + BaseVersion (base_version_copy, base_version, is_latest_version). Loading a save on a newer game build bumps these values. An older executable then refuses to load the file with a version-incompatible message.

Add fixes/version_mismatch.py to read current stamps and rewrite the global and every active slot's stamps to a target version, then recalculate checksums. Kept outside the BaseFix interface since that operates per-slot and this needs the global stamp and all slots to move together.

Add ui/version_mismatch_dialog.py exposing the fix: shows the global version and each active slot's version, defaults to 252 (game 1.16.2) with a free-entry override, validates input as an integer in range, backs up before writing.

Wire a "Mismatched Game/Save Version?" button into the save inspector tab, left of "View All Issues".